### PR TITLE
Regex replacing

### DIFF
--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -32,6 +32,17 @@ foreign import replace
   \  };\
   \}" :: Regex -> String -> String -> String
 
+foreign import replace'
+  "function replace$prime(r) {\
+  \  return function(f) {\
+  \    return function(s2) {\
+  \      return s2.replace(r, function (match) {\
+  \        return f(match)(Array.prototype.splice.call(arguments, 1, arguments.length - 3));\
+  \      });\
+  \    };\
+  \  };\
+  \}" :: Regex -> (String -> [String] -> String) -> String -> String
+
 foreign import search
   "function search(r) {\
   \  return function (s) {\


### PR DESCRIPTION
- Renamed `replaceR` to `replace` as qualified importing seems preferrable to type-specific naming to me.
- Add `replace'` which uses a function `full match -> [match groups] -> replacement` for each match found.
