### PR TITLE
make match safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@
 
     flags :: Regex -> RegexFlags
 
-    match :: Regex -> String -> [String]
+    match :: Regex -> String -> Maybe [String]
 
     parseFlags :: String -> RegexFlags
 

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -14,6 +14,8 @@ module Data.String.Regex (
   split
   ) where
 
+import Data.Function
+import Data.Maybe
 import Data.String (indexOf)
 
 foreign import data Regex :: *
@@ -84,12 +86,14 @@ foreign import test
   \  };\
   \}" :: Regex -> String -> Boolean
 
-foreign import match
-  "function match(r) {\
-  \  return function (s) {\
-  \    return s.match(r); \
-  \  };\
-  \}" :: Regex -> String -> [String]
+foreign import _match
+  "function _match(r, s, Just, Nothing) {\
+  \  var m = s.match(r);\
+  \  return m == null ? Nothing : Just(m);\
+  \}" :: forall r. Fn4 Regex String ([String] -> r) r r
+
+match :: Regex -> String -> Maybe [String]
+match r s = runFn4 _match r s Just Nothing
 
 foreign import replace
   "function replace(r) {\


### PR DESCRIPTION
`String.prototype.match` returns `null` if there is no match. For example:

``` javascript
> 'abc'.match(/x/)
null
```

This change is largely copied from #13.
