### PR TITLE
Fix missing foreign `count` function.

### DIFF
--- a/docs/Data/String.md
+++ b/docs/Data/String.md
@@ -178,7 +178,8 @@ Returns the string without the first `n` characters.
 count :: (Char -> Boolean) -> String -> Int
 ```
 
-Returns the number of characters in the string for which the predicate holds.
+Returns the number of contiguous characters at the beginning
+of the string for which the predicate holds.
 
 #### `split`
 

--- a/src/Data/String.js
+++ b/src/Data/String.js
@@ -120,6 +120,13 @@ exports.drop = function (n) {
   };
 };
 
+exports.count = function (p) {
+  return function (s) {
+    for (var i = 0; i < s.length && p(s.charAt(i)); i++); {}
+    return i;
+  };
+};
+
 exports.split = function (sep) {
   return function (s) {
     return s.split(sep);

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -172,7 +172,8 @@ foreign import take :: Int -> String -> String
 -- | Returns the string without the first `n` characters.
 foreign import drop :: Int -> String -> String
 
--- | Returns the number of characters in the string for which the predicate holds.
+-- | Returns the number of contiguous characters at the beginning
+-- | of the string for which the predicate holds.
 foreign import count :: (Char -> Boolean) -> String -> Int
 
 -- | Returns the substrings of the first string separated along occurences


### PR DESCRIPTION
Also updated the documentation to more accurately reflect the function's
behavior.

I think the function could be given a better name to communicate its
behavior too. Since it's an exported function, I didn't rename it as
part of this fix.