### PR TITLE
Remove unused import

### DIFF
--- a/src/Data/String/Unsafe.purs
+++ b/src/Data/String/Unsafe.purs
@@ -5,8 +5,6 @@ module Data.String.Unsafe
   , charCodeAt
   ) where
 
-import Data.Char
-
 -- | Returns the numeric Unicode value of the character at the given index.
 -- |
 -- | **Unsafe:** throws runtime exception if the index is out of bounds.


### PR DESCRIPTION
The PureScript compiler warns about unused imports as of 0.7.6.