### PR TITLE
Handle Regex syntax errors, resolves #48

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-maybe": "^0.3.0"
+    "purescript-maybe": "^0.3.0",
+    "purescript-either": "^0.2.0"
   },
   "devDependencies": {
     "purescript-assert": "~0.1.0",

--- a/docs/Data/String/Regex.md
+++ b/docs/Data/String/Regex.md
@@ -14,7 +14,7 @@ Wraps Javascript `RegExp` objects.
 
 ##### Instances
 ``` purescript
-instance showRegex :: Show Regex
+Show Regex
 ```
 
 #### `RegexFlags`
@@ -36,10 +36,11 @@ All flags set to false.
 #### `regex`
 
 ``` purescript
-regex :: String -> RegexFlags -> Regex
+regex :: String -> RegexFlags -> Either String Regex
 ```
 
-Constructs a `Regex` from a pattern string and flags.
+Constructs a `Regex` from a pattern string and flags. Fails with
+`Left error` if the pattern contains a syntax error.
 
 #### `source`
 

--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -7,9 +7,17 @@ exports["showRegex'"] = function (r) {
   return "" + r;
 };
 
-exports["regex'"] = function (s1) {
-  return function (s2) {
-    return new RegExp(s1, s2);
+exports["regex'"] = function (left) {
+  return function (right) {
+    return function (s1) {
+      return function (s2) {
+        try {
+          return right(new RegExp(s1, s2));
+        } catch (e) {
+          return left(e.message);
+        }
+      };
+    };
   };
 };
 

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -20,6 +20,7 @@ module Data.String.Regex
 
 import Prelude
 import Data.Maybe (Maybe(..))
+import Data.Either (Either(..))
 import Data.String (contains)
 
 -- | Wraps Javascript `RegExp` objects.
@@ -47,11 +48,16 @@ noFlags = { global     : false
           , sticky     : false
           , unicode    : false }
 
-foreign import regex' :: String -> String -> Regex
+foreign import regex' :: (String -> Either String Regex)
+                      -> (Regex -> Either String Regex)
+                      -> String
+                      -> String
+                      -> Either String Regex
 
--- | Constructs a `Regex` from a pattern string and flags.
-regex :: String -> RegexFlags -> Regex
-regex s f = regex' s $ renderFlags f
+-- | Constructs a `Regex` from a pattern string and flags. Fails with
+-- | `Left error` if the pattern contains a syntax error.
+regex :: String -> RegexFlags -> Either String Regex
+regex s f = regex' Left Right s $ renderFlags f
 
 -- | Returns the pattern string used to construct the given `Regex`.
 foreign import source :: Regex -> String

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -4,28 +4,35 @@ import Prelude
 import Data.Maybe
 import Control.Monad.Eff.Console (log)
 import Data.String.Regex
+import Data.Either (isLeft)
+import Data.Either.Unsafe (fromRight)
 import Test.Assert (assert)
+
+-- | Unsafe version of `regex`.
+regex' :: String -> RegexFlags -> Regex
+regex' pattern flags = fromRight (regex pattern flags)
 
 testStringRegex = do
   log "regex"
-  assert $ test (regex "^a" noFlags) "abc"
-  assert $ not (test (regex "^b" noFlags) "abc")
+  assert $ test (regex' "^a" noFlags) "abc"
+  assert $ not (test (regex' "^b" noFlags) "abc")
+  assert $ isLeft (regex "+" noFlags)
 
   log "match"
-  assert $ match (regex "^abc$" noFlags) "abc" == Just [Just "abc"]
+  assert $ match (regex' "^abc$" noFlags) "abc" == Just [Just "abc"]
 
   log "replace"
-  assert $ replace (regex "-" noFlags) "!" "a-b-c" == "a!b-c"
+  assert $ replace (regex' "-" noFlags) "!" "a-b-c" == "a!b-c"
 
   log "replace'"
-  assert $ replace' (regex "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
+  assert $ replace' (regex' "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
 
   log "search"
-  assert $ search (regex "b" noFlags) "abc" == Just 1
-  assert $ search (regex "d" noFlags) "abc" == Nothing
+  assert $ search (regex' "b" noFlags) "abc" == Just 1
+  assert $ search (regex' "d" noFlags) "abc" == Nothing
 
   log "split"
-  assert $ split (regex "" noFlags) "" == []
-  assert $ split (regex "" noFlags) "abc" == ["a", "b", "c"]
-  assert $ split (regex "b" noFlags) "" == [""]
-  assert $ split (regex "b" noFlags) "abc" == ["a", "c"]
+  assert $ split (regex' "" noFlags) "" == []
+  assert $ split (regex' "" noFlags) "abc" == ["a", "b", "c"]
+  assert $ split (regex' "b" noFlags) "" == [""]
+  assert $ split (regex' "b" noFlags) "abc" == ["a", "c"]


### PR DESCRIPTION
In order to avoid runtime errors, this commit replaces
``` purs
regex :: String -> RegexFlags -> Regex
```
with a safe version:
``` purs
regex :: String -> RegexFlags -> Either String Regex
```
If the Regex contains a syntax error (or invalid flags), the exception
is handled in the FFI code and `Left error` is returned.