### PR TITLE
Deprecate count, resolves #46

### DIFF
--- a/docs/Data/String.md
+++ b/docs/Data/String.md
@@ -194,15 +194,6 @@ drop :: Int -> String -> String
 
 Returns the string without the first `n` characters.
 
-#### `count`
-
-``` purescript
-count :: (Char -> Boolean) -> String -> Int
-```
-
-Returns the number of contiguous characters at the beginning
-of the string for which the predicate holds.
-
 #### `split`
 
 ``` purescript

--- a/docs/Data/String/Regex.md
+++ b/docs/Data/String/Regex.md
@@ -14,7 +14,7 @@ Wraps Javascript `RegExp` objects.
 
 ##### Instances
 ``` purescript
-instance showRegex :: Show Regex
+Show Regex
 ```
 
 #### `RegexFlags`

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -18,7 +18,6 @@ module Data.String
   , singleton
   , localeCompare
   , replace
-  , count
   , take
   , takeWhile
   , drop

--- a/test/Test/Data/String.purs
+++ b/test/Test/Data/String.purs
@@ -138,15 +138,6 @@ testString = do
   assert $ drop 2 "ab" == ""
   assert $ drop 3 "ab" == ""
 
-  log "count"
-  assert $ count (\c -> true) "" == 0
-  assert $ count (\c -> true) "ab" == 2
-  assert $ count (\c -> false) "ab" == 0
-  assert $ count (\c -> c == 'a') "aabbcc" == 2
-  assert $ count (\c -> c == 'b') "aabbcc" == 0
-  assert $ count (\c -> c /= 'a') "aabbcc" == 0
-  assert $ count (\c -> c /= 'b') "aabbcc" == 2
-
   log "split"
   assert $ split "" "" == []
   assert $ split "" "a" == ["a"]


### PR DESCRIPTION
Removes the export for the function `count`.