### PR TITLE
Handle negative arguments in drop, resolves #52

### DIFF
--- a/src/Data/String.js
+++ b/src/Data/String.js
@@ -118,7 +118,7 @@ exports.take = function (n) {
 
 exports.drop = function (n) {
   return function (s) {
-    return s.substr(n);
+    return s.substring(n);
   };
 };
 

--- a/test/Test/Data/String.purs
+++ b/test/Test/Data/String.purs
@@ -131,12 +131,14 @@ testString = do
   assert $ take 1 "ab" == "a"
   assert $ take 2 "ab" == "ab"
   assert $ take 3 "ab" == "ab"
+  assert $ take (-1) "ab" == ""
 
   log "drop"
   assert $ drop 0 "ab" == "ab"
   assert $ drop 1 "ab" == "b"
   assert $ drop 2 "ab" == ""
   assert $ drop 3 "ab" == ""
+  assert $ drop (-1) "ab" == "ab"
 
   log "count"
   assert $ count (\c -> true) "" == 0


### PR DESCRIPTION
With this change, `drop` handles negative arguments consistently:
``` purs
drop (-2) "abcdef" == drop 0 "abcdef" == "abcdef"
```