### PR TITLE
Reset Regex state after calling 'test', resolves #7

### DIFF
--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -37,7 +37,10 @@ exports.flags = function (r) {
 
 exports.test = function (r) {
   return function (s) {
-    return r.test(s);
+    var lastIndex = r.lastIndex;
+    var result = r.test(s);
+    r.lastIndex = lastIndex;
+    return result;
   };
 };
 

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -84,7 +84,9 @@ parseFlags s =
   , unicode: contains "u" s
   }
 
--- | Returns `true` if the `Regex` matches the string.
+-- | Returns `true` if the `Regex` matches the string. In contrast to
+-- | `RegExp.prototype.test()` in JavaScript, `test` does not affect
+-- | the `lastIndex` property of the Regex.
 foreign import test :: Regex -> String -> Boolean
 
 foreign import _match :: (forall r. r -> Maybe r)

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -36,3 +36,10 @@ testStringRegex = do
   assert $ split (regex' "" noFlags) "abc" == ["a", "b", "c"]
   assert $ split (regex' "b" noFlags) "" == [""]
   assert $ split (regex' "b" noFlags) "abc" == ["a", "c"]
+
+  log "test"
+  -- Ensure that we have referential transparency for calls to 'test'. No
+  -- global state should be maintained between these two calls:
+  let pattern = regex' "a" (parseFlags "g")
+  assert $ test pattern "a"
+  assert $ test pattern "a"


### PR DESCRIPTION
Previously, the second `assert` in the following code would fail:
``` purs
let pattern = regex "a" (parseFlags "g")
assert $ test pattern "a"
assert $ test pattern "a"
```
The reason is that the RegExp object in JavaScript maintains a global state (for details, see the discussion in #7).

This commit resets the `lastIndex` property on the RegExp object, such that both calls to `test` return the same result.