### PR TITLE
Export `count` again

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "private": true,
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
-    "build": "jshint src && jscs src && psa \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\" --censor-lib --strict",
-    "test": "psc \"src/**/*.purs\" \"bower_components/purescript-*/src/**/*.purs\" \"test/**/*.purs\" && psc-bundle \"output/**/*.js\" --module Test.Main --main Test.Main | node"
+    "build": "jshint src && jscs src && pulp build --censor-lib --strict",
+    "test": "pulp test"
   },
   "devDependencies": {
     "jscs": "^2.8.0",
     "jshint": "^2.9.1",
-    "pulp": "^8.2.0",
-    "purescript-psa": "^0.3.8",
+    "pulp": "^9.0.1",
+    "purescript-psa": "^0.3.9",
     "rimraf": "^2.5.0"
   }
 }

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -23,6 +23,7 @@ module Data.String
   , dropWhile
   , stripPrefix
   , stripSuffix
+  , count
   , split
   , toCharArray
   , toLower

--- a/test/Test/Data/String.purs
+++ b/test/Test/Data/String.purs
@@ -142,6 +142,12 @@ testString = do
   assert $ drop 3 "ab" == ""
   assert $ drop (-1) "ab" == "ab"
 
+  log "count"
+  assert $ count (_ == 'a') "" == 0
+  assert $ count (_ == 'a') "ab" == 1
+  assert $ count (_ == 'a') "aaab" == 3
+  assert $ count (_ == 'a') "abaa" == 1
+
   log "split"
   assert $ split "" "" == []
   assert $ split "" "a" == ["a"]
@@ -167,4 +173,3 @@ testString = do
   assert $ joinWith "" [] == ""
   assert $ joinWith "" ["a", "b"] == "ab"
   assert $ joinWith "--" ["a", "b", "c"] == "a--b--c"
-


### PR DESCRIPTION
This used to be exported (I'm updating a library to 0.9 and it was using `count`) but is not now for some reason, so, it's back.