### PR TITLE
Use a Tuple in splitAt

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "purescript-either": "^2.0.0",
-    "purescript-maybe": "^2.0.0"
+    "purescript-maybe": "^2.0.0",
+    "purescript-tuples": "^3.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^2.0.0",

--- a/src/Data/String.js
+++ b/src/Data/String.js
@@ -146,10 +146,12 @@ exports.split = function (sep) {
 
 exports._splitAt = function (just) {
   return function (nothing) {
-    return function (i) {
-      return function (s) {
-        return i >= 0 && i < s.length ?
-               just([s.substring(0, i), s.substring(i)]) : nothing;
+    return function (tuple) {
+      return function (i) {
+        return function (s) {
+          return i >= 0 && i < s.length ?
+            just(tuple(s.substring(0, i))(s.substring(i))) : nothing;
+        };
       };
     };
   };

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -41,6 +41,7 @@ import Prelude
 import Data.Maybe (Maybe(..), isJust)
 import Data.Newtype (class Newtype)
 import Data.String.Unsafe as U
+import Data.Tuple (Tuple(..))
 
 -- | A newtype used in cases where there is a string to be matched.
 newtype Pattern = Pattern String
@@ -232,14 +233,15 @@ foreign import count :: (Char -> Boolean) -> String -> Int
 foreign import split :: Pattern -> String -> Array String
 
 -- | Returns the substrings of split at the given index, if the index is within bounds.
-splitAt :: Int -> String -> Maybe (Array String)
-splitAt = _splitAt Just Nothing
+splitAt :: Int -> String -> Maybe (Tuple String String)
+splitAt = _splitAt Just Nothing Tuple
 
 foreign import _splitAt :: (forall a. a -> Maybe a)
                         -> (forall a. Maybe a)
+                        -> (forall a b. a -> b -> Tuple a b)
                         -> Int
                         -> String
-                        -> Maybe (Array String)
+                        -> Maybe (Tuple String String)
 
 -- | Converts the string into an array of characters.
 foreign import toCharArray :: String -> Array Char

--- a/test/Test/Data/String.purs
+++ b/test/Test/Data/String.purs
@@ -6,6 +6,7 @@ import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
 import Data.Maybe (Maybe(..), isNothing)
+import Data.Tuple (Tuple(..))
 import Data.String
 
 import Test.Assert (ASSERT, assert)
@@ -161,9 +162,9 @@ testString = do
 
   log "splitAt"
   assert $ splitAt 1 "" == Nothing
-  assert $ splitAt 0 "a" == Just ["", "a"]
-  assert $ splitAt 1 "ab" == Just ["a", "b"]
-  assert $ splitAt 3 "aabcc" == Just ["aab", "cc"]
+  assert $ splitAt 0 "a" == Just (Tuple "" "a")
+  assert $ splitAt 1 "ab" == Just (Tuple "a" "b")
+  assert $ splitAt 3 "aabcc" == Just (Tuple "aab" "cc")
   assert $ splitAt (-1) "abc" == Nothing
 
   log "toCharArray"


### PR DESCRIPTION
Fixes #69.

This introduces a dependency on `tuples`, but `tuples` only depends on `foldable-traversable` itself, so this change shouldn't add any additional transitive dependencies.