### PR TITLE
add codepoint-based string functions as Data.String.CodePoints

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "purescript-maybe": "^3.0.0",
     "purescript-partial": "^1.2.0",
     "purescript-unfoldable": "^3.0.0",
-    "purescript-lists": "^4.1.1",
     "purescript-arrays": "^4.0.1"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,10 @@
     "purescript-either": "^3.0.0",
     "purescript-gen": "^1.1.0",
     "purescript-maybe": "^3.0.0",
-    "purescript-partial": "^1.2.0"
+    "purescript-partial": "^1.2.0",
+    "purescript-unfoldable": "^3.0.0",
+    "purescript-lists": "^4.1.1",
+    "purescript-arrays": "^4.0.1"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0",

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -40,7 +40,7 @@ import Prelude
 
 import Data.Maybe (Maybe(..), isJust)
 import Data.Newtype (class Newtype)
-import Data.String.Unsafe (charAt) as U
+import Data.String.Unsafe as U
 
 -- | A newtype used in cases where there is a string to be matched.
 newtype Pattern = Pattern String

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -36,11 +36,11 @@ module Data.String
   , joinWith
   ) where
 
-import Prelude
+import Prelude (class Ord, class Eq, class Show, Ordering(LT, EQ, GT), zero, one, (<<<), (<>), (==), ($), (-))
 
 import Data.Maybe (Maybe(..), isJust)
 import Data.Newtype (class Newtype)
-import Data.String.Unsafe as U
+import Data.String.Unsafe (charAt) as U
 
 -- | A newtype used in cases where there is a string to be matched.
 newtype Pattern = Pattern String

--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -36,7 +36,7 @@ module Data.String
   , joinWith
   ) where
 
-import Prelude (class Ord, class Eq, class Show, Ordering(LT, EQ, GT), zero, one, (<<<), (<>), (==), ($), (-))
+import Prelude
 
 import Data.Maybe (Maybe(..), isJust)
 import Data.Newtype (class Newtype)

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -24,17 +24,17 @@ exports._codePointAt = function (fallback) {
           return function (str) {
             var length = str.length;
             if (index < 0 || index >= length) return Nothing;
-            if (hasArrayFrom) {
-              var cps = Array.from(str);
-              if (index >= cps.length) return Nothing;
-              return Just(unsafeCodePointAt0(cps[index]));
-            } else if (hasStringIterator) {
+            if (hasStringIterator) {
               var iter = str[Symbol.iterator]();
               for (var i = index;; --i) {
                 var o = iter.next();
                 if (o.done) return Nothing;
                 if (i === 0) return Just(unsafeCodePointAt0(o.value));
               }
+            } else if (hasArrayFrom) {
+              var cps = Array.from(str);
+              if (index >= cps.length) return Nothing;
+              return Just(unsafeCodePointAt0(cps[index]));
             }
             return fallback(index)(str);
           };

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -69,7 +69,7 @@ exports._take = function (fallback) {
   return function (n) {
     if (hasArrayFrom) {
       return function (str) {
-        return Array.from(str).slice(0, n).join('');
+        return Array.from(str).slice(0, Math.max(0, n)).join('');
       };
     } else if (hasStringIterator) {
       return function (str) {

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -31,10 +31,6 @@ exports._codePointAt = function (fallback) {
                 if (o.done) return Nothing;
                 if (i === 0) return Just(unsafeCodePointAt0(o.value));
               }
-            } else if (hasArrayFrom) {
-              var cps = Array.from(str);
-              if (index >= cps.length) return Nothing;
-              return Just(unsafeCodePointAt0(cps[index]));
             }
             return fallback(index)(str);
           };

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -1,5 +1,5 @@
 var hasArrayFrom = typeof Array.from === 'function';
-var hasStringIterator = 
+var hasStringIterator =
   typeof Symbol !== 'undefined' &&
   Symbol != null &&
   typeof Symbol.iterator !== 'undefined' &&

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -17,6 +17,15 @@ function fromCodePoint(cp) {
   return cu1 + cu2;
 }
 
+var codePointAt0 = hasCodePointAt
+  ? function (str) { return str.codePointAt(0); }
+  : function (str) {
+    if (str.length === 1) {
+      return str.charCodeAt(0);
+    }
+    return ((str.charCodeAt(0) - 0xD800) * 0x400 + (str.charCodeAt(1) - 0xDC00) + 0x10000);
+  };
+
 exports._codePointAt = function (fallback) {
   return function (Just) {
     return function (Nothing) {
@@ -24,16 +33,16 @@ exports._codePointAt = function (fallback) {
         return function (str) {
           var length = str.length;
           if (index < 0 || index >= length) return Nothing;
-          if (hasArrayFrom && hasCodePointAt) {
+          if (hasArrayFrom) {
             var cps = Array.from(str);
             if (index >= cps.length) return Nothing;
-            return Just(cps[index].codePointAt(0));
+            return Just(codePointAt0(cps[index]));
           } else if (hasStringIterator) {
             var iter = str[Symbol.iterator]();
             for (var i = index;; --i) {
               var o = iter.next();
               if (o.done) return Nothing;
-              if (i === 0) return Just(o.value);
+              if (i === 0) return Just(codePointAt0(o.value));
             }
           }
           return fallback(index)(str);
@@ -70,6 +79,7 @@ exports._count = function (isLead) {
 };
 
 exports.fromCodePointArray = hasFromCodePoint
+  // TODO: using F.p.apply here will fail for very large strings; use alternative implementation for very large strings
   ? function (cps) { return String.fromCodePoint.apply(String, cps); }
   : function (cps) { return cps.map(fromCodePoint).join(""); };
 
@@ -93,23 +103,23 @@ exports._take = function (fallback) {
         return accum;
       };
     }
-    return fallback;
+    return fallback(n);
   };
 };
 
 exports._toCodePointArray = function (fallback) {
-  if (hasArrayFrom && hasCodePointAt) {
+  if (hasArrayFrom) {
     return function (str) {
-      return Array.from(str, function (x) { return x.codePointAt(0); });
+      return Array.from(str, codePointAt0);
     };
-  } else if (hasStringIterator && hasCodePointAt) {
+  } else if (hasStringIterator) {
     return function (str) {
       var accum = [];
       var iter = str[Symbol.iterator]();
       for (;;) {
         var o = iter.next();
         if (o.done) return accum;
-        accum.push(o.value.codePointAt(0));
+        accum.push(codePointAt0(o.value));
       }
     };
   }

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -38,7 +38,7 @@ exports._codePointAt = function (fallback) {
   };
 };
 
-exports.singleton = fromCodePoint;
+exports.singleton = hasFromCodePoint ? String.fromCodePoint : fromCodePoint;
 
 exports._take = function (fallback) {
   return function (n) {
@@ -80,7 +80,7 @@ exports._toCodePointArray = function (fallback) {
 
 exports.fromCodePointArray = function (cps) {
   if (hasFromCodePoint) {
-    return String.fromCodePoint.apply(cps);
+    return String.fromCodePoint.apply(String, cps);
   }
   return cps.map(fromCodePoint).join('');
 };

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -21,6 +21,7 @@ exports._codePointAt = function (fallback) {
             if (cps.length <= index) return Nothing;
             return Just(cps[index]);
           } else if (hasStringIterator) {
+            var i = index;
             var iter = str[Symbol.iterator]();
             for (;;) {
               var o = iter.next();

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -38,6 +38,13 @@ exports._codePointAt = function (fallback) {
   };
 };
 
+exports.fromCodePointArray = function (cps) {
+  if (hasFromCodePoint) {
+    return String.fromCodePoint.apply(String, cps);
+  }
+  return cps.map(fromCodePoint).join('');
+};
+
 exports.singleton = hasFromCodePoint ? String.fromCodePoint : fromCodePoint;
 
 exports._take = function (fallback) {
@@ -75,14 +82,6 @@ exports._toCodePointArray = function (fallback) {
     }
     return fallback(str);
   };
-};
-
-
-exports.fromCodePointArray = function (cps) {
-  if (hasFromCodePoint) {
-    return String.fromCodePoint.apply(String, cps);
-  }
-  return cps.map(fromCodePoint).join('');
 };
 
 function fromCodePoint(cp) {

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -73,6 +73,8 @@ exports._count = function (isLead) {
 exports._fromCodePointArray = function (singleton) {
   return hasFromCodePoint
     ? function (cps) {
+      // Function.prototype.apply will fail for very large second parameters,
+      // so we don't use it for arrays with 10KB or more entries.
       if (cps.length < 10240) {
         return String.fromCodePoint.apply(String, cps);
       }

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -78,8 +78,12 @@ exports._count = function (isLead) {
 
 exports._fromCodePointArray = function (singleton) {
   return hasFromCodePoint
-    // TODO: using F.p.apply here will fail for very large strings; use alternative implementation for very large strings
-    ? function (cps) { return String.fromCodePoint.apply(String, cps); }
+    ? function (cps) {
+      if (cps.length < 10240) {
+        return String.fromCodePoint.apply(String, cps);
+      }
+      return cps.map(singleton).join("");
+    }
     : function (cps) { return cps.map(singleton).join(""); };
 };
 

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -74,8 +74,8 @@ exports._fromCodePointArray = function (singleton) {
   return hasFromCodePoint
     ? function (cps) {
       // Function.prototype.apply will fail for very large second parameters,
-      // so we don't use it for arrays with 10KB or more entries.
-      if (cps.length < 10240) {
+      // so we don't use it for arrays with 10,000 or more entries.
+      if (cps.length < 10e3) {
         return String.fromCodePoint.apply(String, cps);
       }
       return cps.map(singleton).join("");

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -1,0 +1,71 @@
+const hasArrayFrom = typeof Array.from === 'function';
+const hasStringIterator = 
+  typeof Symbol !== 'undefined' &&
+  Symbol != null &&
+  typeof Symbol.iterator !== 'undefined' &&
+  typeof String.prototype[Symbol.iterator] === 'function';
+
+exports._codePointAt = function (fallback) {
+  return function (Just) {
+    return function (Nothing) {
+      return function (relIndex) {
+        return function (str) {
+          let length = str.length;
+          if (length <= relIndex) return Nothing;
+          let index = relIndex < 0 ? ((relIndex % length) + length) % length : relIndex;
+          if (typeof String.prototype.codePointAt === 'function') {
+            let cp = str.codePointAt(index);
+            return cp == null ? Nothing : Just(cp);
+          } else if (hasArrayFrom) {
+            let cps = Array.from(str);
+            if (cps.length <= index) return Nothing;
+            return Just(cps[index]);
+          } else if (hasStringIterator) {
+            let iter = str[Symbol.iterator]();
+            for (;;) {
+              let { value, done } = iter.next();
+              if (done) return Nothing;
+              if (i == 0) return Just(value);
+              --i;
+            }
+          }
+          return fallback(index)(str);
+        };
+      };
+    };
+  };
+};
+
+exports._toCodePointArray = function (str) {
+  if (hasArrayFrom) {
+    return Array.from(str);
+  } else if (hasStringIterator) {
+    let accum = [];
+    let iter = str[Symbol.iterator]();
+    for (;;) {
+      let { value, done } = iter.next();
+      if (done) return accum;
+      accum.push(value);
+    }
+  }
+  let accum = [];
+  for (let cuCount = 0; cuCount < str.length; ++cuCount) {
+    let cu = str[cuCount];
+    let cp = cu;
+    if (isLead(cu) && cuCount + 1 < str.length) {
+      let lead = cu;
+      let trail = str[cuCount + 1];
+      if (isTrail(trail)) {
+        cp = unsurrogate(lead, trail);
+      }
+    }
+    accum.push(cp);
+  }
+  return accum;
+};
+
+function isLead(cu) { return 0xD800 <= cu && cu <= 0xDBFF; }
+function isTrail(cu) { return 0xDC00 <= cu && cu <= 0xDFFF; }
+function unsurrogate(h, l) {
+  return (h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000;
+}

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -10,12 +10,6 @@ var hasStringIterator =
 var hasFromCodePoint = typeof String.prototype.fromCodePoint === "function";
 var hasCodePointAt = typeof String.prototype.codePointAt === "function";
 
-exports._unsafeCharCodeAt = function (i) {
-  return function (str) {
-    return str.charCodeAt(i);
-  };
-};
-
 exports._unsafeCodePointAt0 = function (fallback) {
   return hasCodePointAt
     ? function (str) { return str.codePointAt(0); }

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -38,6 +38,8 @@ exports._codePointAt = function (fallback) {
   };
 };
 
+exports.singleton = fromCodePoint;
+
 exports._take = function (fallback) {
   return function (n) {
     return function (str) {

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -1,5 +1,5 @@
-const hasArrayFrom = typeof Array.from === 'function';
-const hasStringIterator = 
+var hasArrayFrom = typeof Array.from === 'function';
+var hasStringIterator = 
   typeof Symbol !== 'undefined' &&
   Symbol != null &&
   typeof Symbol.iterator !== 'undefined' &&
@@ -10,22 +10,22 @@ exports._codePointAt = function (fallback) {
     return function (Nothing) {
       return function (relIndex) {
         return function (str) {
-          let length = str.length;
+          var length = str.length;
           if (length <= relIndex) return Nothing;
-          let index = relIndex < 0 ? ((relIndex % length) + length) % length : relIndex;
+          var index = relIndex < 0 ? ((relIndex % length) + length) % length : relIndex;
           if (typeof String.prototype.codePointAt === 'function') {
-            let cp = str.codePointAt(index);
+            var cp = str.codePointAt(index);
             return cp == null ? Nothing : Just(cp);
           } else if (hasArrayFrom) {
-            let cps = Array.from(str);
+            var cps = Array.from(str);
             if (cps.length <= index) return Nothing;
             return Just(cps[index]);
           } else if (hasStringIterator) {
-            let iter = str[Symbol.iterator]();
+            var iter = str[Symbol.iterator]();
             for (;;) {
-              let { value, done } = iter.next();
-              if (done) return Nothing;
-              if (i == 0) return Just(value);
+              var o = iter.next();
+              if (o.done) return Nothing;
+              if (i == 0) return Just(o.value);
               --i;
             }
           }
@@ -36,36 +36,19 @@ exports._codePointAt = function (fallback) {
   };
 };
 
-exports._toCodePointArray = function (str) {
-  if (hasArrayFrom) {
-    return Array.from(str);
-  } else if (hasStringIterator) {
-    let accum = [];
-    let iter = str[Symbol.iterator]();
-    for (;;) {
-      let { value, done } = iter.next();
-      if (done) return accum;
-      accum.push(value);
-    }
-  }
-  let accum = [];
-  for (let cuCount = 0; cuCount < str.length; ++cuCount) {
-    let cu = str[cuCount];
-    let cp = cu;
-    if (isLead(cu) && cuCount + 1 < str.length) {
-      let lead = cu;
-      let trail = str[cuCount + 1];
-      if (isTrail(trail)) {
-        cp = unsurrogate(lead, trail);
+exports._toCodePointArray = function (fallback) {
+  return function (str) {
+    if (hasArrayFrom) {
+      return Array.from(str);
+    } else if (hasStringIterator) {
+      var accum = [];
+      var iter = str[Symbol.iterator]();
+      for (;;) {
+        var o = iter.next();
+        if (o.done) return accum;
+        accum.push(o.value);
       }
     }
-    accum.push(cp);
-  }
-  return accum;
+    return fallback(str);
+  };
 };
-
-function isLead(cu) { return 0xD800 <= cu && cu <= 0xDBFF; }
-function isTrail(cu) { return 0xDC00 <= cu && cu <= 0xDFFF; }
-function unsurrogate(h, l) {
-  return (h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000;
-}

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -1,11 +1,21 @@
-var hasArrayFrom = typeof Array.from === 'function';
+"use strict";
+/* global Symbol */
+
+var hasArrayFrom = typeof Array.from === "function";
 var hasStringIterator =
-  typeof Symbol !== 'undefined' &&
+  typeof Symbol !== "undefined" &&
   Symbol != null &&
-  typeof Symbol.iterator !== 'undefined' &&
-  typeof String.prototype[Symbol.iterator] === 'function';
-var hasFromCodePoint = typeof String.prototype.fromCodePoint === 'function';
-var hasCodePointAt = typeof String.prototype.codePointAt === 'function';
+  typeof Symbol.iterator !== "undefined" &&
+  typeof String.prototype[Symbol.iterator] === "function";
+var hasFromCodePoint = typeof String.prototype.fromCodePoint === "function";
+var hasCodePointAt = typeof String.prototype.codePointAt === "function";
+
+function fromCodePoint(cp) {
+  if (cp <= 0xFFFF) return String.fromCharCode(cp);
+  var cu1 = String.fromCharCode(Math.floor((cp - 0x10000) / 0x400) + 0xD800);
+  var cu2 = String.fromCharCode((cp - 0x10000) % 0x400 + 0xDC00);
+  return cu1 + cu2;
+}
 
 exports._codePointAt = function (fallback) {
   return function (Just) {
@@ -23,7 +33,7 @@ exports._codePointAt = function (fallback) {
             for (var i = index;; --i) {
               var o = iter.next();
               if (o.done) return Nothing;
-              if (i == 0) return Just(o.value);
+              if (i === 0) return Just(o.value);
             }
           }
           return fallback(index)(str);
@@ -61,7 +71,7 @@ exports._count = function (isLead) {
 
 exports.fromCodePointArray = hasFromCodePoint
   ? function (cps) { return String.fromCodePoint.apply(String, cps); }
-  : function (cps) { return cps.map(fromCodePoint).join(''); };
+  : function (cps) { return cps.map(fromCodePoint).join(""); };
 
 exports.singleton = hasFromCodePoint ? String.fromCodePoint : fromCodePoint;
 
@@ -69,7 +79,7 @@ exports._take = function (fallback) {
   return function (n) {
     if (hasArrayFrom) {
       return function (str) {
-        return Array.from(str).slice(0, Math.max(0, n)).join('');
+        return Array.from(str).slice(0, Math.max(0, n)).join("");
       };
     } else if (hasStringIterator) {
       return function (str) {
@@ -105,10 +115,3 @@ exports._toCodePointArray = function (fallback) {
   }
   return fallback;
 };
-
-function fromCodePoint(cp) {
-  if (cp <= 0xFFFF) return String.fromCharCode(cp);
-  var cu1 = String.fromCharCode(Math.floor((cp - 0x10000) / 0x400) + 0xD800);
-  var cu2 = String.fromCharCode((cp - 0x10000) % 0x400 + 0xDC00);
-  return cu1 + cu2;
-}

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -38,6 +38,30 @@ exports._codePointAt = function (fallback) {
   };
 };
 
+exports._count = function (isLead) {
+  return function (isTrail) {
+    return function (unsurrogate) {
+      return function (pred) {
+        return function (str) {
+          for (var cuCount = 0, cpCount = 0; cuCount < str.length; ++cuCount, ++cpCount) {
+            var lead = str.charCodeAt(cuCount);
+            var cp = lead;
+            if (isLead(lead) && cuCount + 1 < str.length) {
+              var trail = str.charCodeAt(cuCount + 1);
+              if (isTrail(trail)) {
+                cp = unsurrogate(lead, trail);
+                ++cuCount;
+              }
+            }
+            if (!pred(cp)) return cpCount;
+          }
+          return str.length;
+        };
+      };
+    };
+  };
+};
+
 exports.fromCodePointArray = function (cps) {
   if (hasFromCodePoint) {
     return String.fromCodePoint.apply(String, cps);

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -80,7 +80,9 @@ exports._fromCodePointArray = function (singleton) {
       }
       return cps.map(singleton).join("");
     }
-    : function (cps) { return cps.map(singleton).join(""); };
+    : function (cps) {
+      return cps.map(singleton).join("");
+    };
 };
 
 exports._singleton = function (fallback) {
@@ -89,11 +91,7 @@ exports._singleton = function (fallback) {
 
 exports._take = function (fallback) {
   return function (n) {
-    if (hasArrayFrom) {
-      return function (str) {
-        return Array.from(str).slice(0, Math.max(0, n)).join("");
-      };
-    } else if (hasStringIterator) {
+    if (hasStringIterator) {
       return function (str) {
         var accum = "";
         var iter = str[Symbol.iterator]();
@@ -114,16 +112,6 @@ exports._toCodePointArray = function (fallback) {
     if (hasArrayFrom) {
       return function (str) {
         return Array.from(str, unsafeCodePointAt0);
-      };
-    } else if (hasStringIterator) {
-      return function (str) {
-        var accum = [];
-        var iter = str[Symbol.iterator]();
-        for (;;) {
-          var o = iter.next();
-          if (o.done) return accum;
-          accum.push(unsafeCodePointAt0(o.value));
-        }
       };
     }
     return fallback;

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -40,29 +40,22 @@ exports._codePointAt = function (fallback) {
   };
 };
 
-exports._count = function (isLead) {
-  return function (isTrail) {
-    return function (unsurrogate) {
+exports._count = function (fallback) {
+  return function (unsafeCodePointAt0) {
+    if (hasStringIterator) {
       return function (pred) {
         return function (str) {
-          var cpCount = 0;
-          for (var cuCount = 0; cuCount < str.length; ++cuCount) {
-            var lead = str.charCodeAt(cuCount);
-            var cp = lead;
-            if (isLead(lead) && cuCount + 1 < str.length) {
-              var trail = str.charCodeAt(cuCount + 1);
-              if (isTrail(trail)) {
-                cp = unsurrogate(lead)(trail);
-                ++cuCount;
-              }
-            }
+          var iter = str[Symbol.iterator]();
+          for (var cpCount = 0; ; ++cpCount) {
+            var o = iter.next();
+            if (o.done) return cpCount;
+            var cp = unsafeCodePointAt0(o.value);
             if (!pred(cp)) return cpCount;
-            ++cpCount;
           }
-          return cpCount;
         };
       };
-    };
+    }
+    return fallback;
   };
 };
 

--- a/src/Data/String/CodePoints.js
+++ b/src/Data/String/CodePoints.js
@@ -10,13 +10,6 @@ var hasStringIterator =
 var hasFromCodePoint = typeof String.prototype.fromCodePoint === "function";
 var hasCodePointAt = typeof String.prototype.codePointAt === "function";
 
-function fromCodePoint(cp) {
-  if (cp <= 0xFFFF) return String.fromCharCode(cp);
-  var cu1 = String.fromCharCode(Math.floor((cp - 0x10000) / 0x400) + 0xD800);
-  var cu2 = String.fromCharCode((cp - 0x10000) % 0x400 + 0xDC00);
-  return cu1 + cu2;
-}
-
 var codePointAt0 = hasCodePointAt
   ? function (str) { return str.codePointAt(0); }
   : function (str) {
@@ -78,12 +71,16 @@ exports._count = function (isLead) {
   };
 };
 
-exports.fromCodePointArray = hasFromCodePoint
-  // TODO: using F.p.apply here will fail for very large strings; use alternative implementation for very large strings
-  ? function (cps) { return String.fromCodePoint.apply(String, cps); }
-  : function (cps) { return cps.map(fromCodePoint).join(""); };
+exports._fromCodePointArray = function (singleton) {
+  return hasFromCodePoint
+    // TODO: using F.p.apply here will fail for very large strings; use alternative implementation for very large strings
+    ? function (cps) { return String.fromCodePoint.apply(String, cps); }
+    : function (cps) { return cps.map(singleton).join(""); };
+};
 
-exports.singleton = hasFromCodePoint ? String.fromCodePoint : fromCodePoint;
+exports._singleton = function (fallback) {
+  return hasFromCodePoint ? String.fromCodePoint : fallback;
+};
 
 exports._take = function (fallback) {
   return function (n) {

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -15,7 +15,7 @@ module CodePoints
   , length
   --, replace
   --, replaceAll
-  --, singleton
+  , singleton
   --, split
   --, splitAt
   --, stripPrefix
@@ -85,6 +85,9 @@ drop n s = fromCodePointArray (Array.drop n (toCodePointArray s))
 
 length :: String -> Int
 length = Array.length <<< toCodePointArray
+
+
+foreign import singleton :: CodePoint -> String
 
 
 take :: Int -> String -> String

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -1,5 +1,6 @@
 module CodePoints
-  ( CodePoint()
+  ( module StringReExports
+  , CodePoint()
   , codePointAt
   , codePointFromInt
   , codePointToInt
@@ -16,10 +17,8 @@ module CodePoints
   , splitAt
   , take
   --, takeWhile
-  , uncons
   , toCodePointArray
-
-  , module StringReExports
+  , uncons
   ) where
 
 import Data.Array as Array

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -33,7 +33,8 @@ import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.String as String
 import Data.String.Unsafe as Unsafe
--- WARN: This list must be updated to re-export any exports added to Data.String. That makes me sad.
+-- WARN: In order for this module to be a drop-in replacement for Data.String,
+-- this list must be updated to re-export any exports added to Data.String.
 import Data.String (Pattern(..), Replacement(..), charAt, charCodeAt, contains, fromCharArray, joinWith, localeCompare, null, replace, replaceAll, split, stripPrefix, stripSuffix, toChar, toCharArray, toLower, toUpper, trim) as StringReExports
 import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -79,12 +79,11 @@ foreign import _unsafeCodePointAt0
 
 unsafeCodePointAt0Fallback :: String -> CodePoint
 unsafeCodePointAt0Fallback s =
+  let cu0 = Unsafe.charCodeAt 0 s in
+  let cu1 = Unsafe.charCodeAt 1 s in
   if isLead cu0 && isTrail cu1
      then unsurrogate cu0 cu1
      else CodePoint cu0
-  where
-    cu0 = Unsafe.charCodeAt 0 s
-    cu1 = Unsafe.charCodeAt 1 s
 
 
 -- | Returns the first code point of the string after dropping the given number
@@ -198,10 +197,10 @@ foreign import _singleton
 
 singletonFallback :: CodePoint -> String
 singletonFallback (CodePoint cp) | cp <= 0xFFFF = fromCharCode cp
-singletonFallback (CodePoint cp) = fromCharCode lead <> fromCharCode trail
-  where
-    lead = ((cp - 0x10000) / 0x400) + 0xD800
-    trail = (cp - 0x10000) `mod` 0x400 + 0xDC00
+singletonFallback (CodePoint cp) =
+  let lead = ((cp - 0x10000) / 0x400) + 0xD800 in
+  let trail = (cp - 0x10000) `mod` 0x400 + 0xDC00 in
+  fromCharCode lead <> fromCharCode trail
 
 
 -- | Returns a record with strings created from the code points on either side

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -16,7 +16,7 @@ module CodePoints
   , splitAt
   , take
   --, takeWhile
-  --, uncons
+  , uncons
   , toCodePointArray
 
   , module StringReExports
@@ -79,6 +79,9 @@ drop :: Int -> String -> String
 drop n s = fromCodePointArray (Array.drop n (toCodePointArray s))
 
 
+foreign import fromCodePointArray :: Array CodePoint -> String
+
+
 length :: String -> Int
 length = Array.length <<< toCodePointArray
 
@@ -124,4 +127,5 @@ toCodePointArrayFallback s = unfoldr decode (fromFoldable (toCharCode <$> toChar
   decode Nil = Nothing
 
 
-foreign import fromCodePointArray :: Array CodePoint -> String
+uncons :: String -> Maybe { head :: CodePoint, tail :: String }
+uncons s  = { head: _, tail: drop 1 s } <$> codePointAt 0 s

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -21,6 +21,8 @@ module Data.String.CodePoints
   , uncons
   ) where
 
+import Prelude
+
 import Data.Array as Array
 import Data.Char as Char
 import Data.List (List(Cons, Nil), fromFoldable)
@@ -32,7 +34,6 @@ import Data.String.Unsafe as Unsafe
 import Data.String (Pattern(..), Replacement(..), charAt, charCodeAt, contains, fromCharArray, joinWith, localeCompare, null, replace, replaceAll, split, stripPrefix, stripSuffix, toChar, toCharArray, toLower, toUpper, trim) as StringReExports
 import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
-import Prelude (class Eq, class Ord, (&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<), (/), (<>), (==), mod)
 
 
 newtype CodePoint = CodePoint Int

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -77,11 +77,13 @@ foreign import _unsafeCodePointAt0
   -> CodePoint
 
 unsafeCodePointAt0Fallback :: String -> CodePoint
-unsafeCodePointAt0Fallback s | String.length s == 1 = CodePoint (Unsafe.charCodeAt 0 s)
-unsafeCodePointAt0Fallback s = CodePoint (unsurrogate lead trail)
+unsafeCodePointAt0Fallback s =
+  if isLead cu0 && isTrail cu1
+     then unsurrogate cu0 cu1
+     else CodePoint cu0
   where
-    lead = Unsafe.charCodeAt 0 s
-    trail = Unsafe.charCodeAt 1 s
+    cu0 = Unsafe.charCodeAt 0 s
+    cu1 = Unsafe.charCodeAt 1 s
 
 
 codePointAt :: Int -> String -> Maybe CodePoint

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -210,9 +210,9 @@ toCodePointArrayFallback :: String -> Array CodePoint
 toCodePointArrayFallback s = unfoldr decode (fromFoldable (Char.toCharCode <$> String.toCharArray s))
   where
   decode :: List Int -> Maybe (Tuple CodePoint (List Int))
-  decode (Cons h (Cons l rest)) | isLead h && isTrail l
-    = Just (Tuple (unsurrogate h l) rest)
-  decode (Cons c rest) = Just (Tuple (CodePoint c) rest)
+  decode (Cons cu0 (Cons cu1 rest)) | isLead cu0 && isTrail cu1
+    = Just (Tuple (unsurrogate cu0 cu1) rest)
+  decode (Cons cu rest) = Just (Tuple (CodePoint cu) rest)
   decode Nil = Nothing
 
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -1,3 +1,7 @@
+-- | These functions allow PureScript strings to be treated as if they were
+-- | sequences of Unicode code points instead of their true underlying
+-- | implementation (sequences of UTF-16 code units). For nearly all uses of
+-- | strings, these functions should be preferred over the ones in Data.String.
 module Data.String.CodePoints
   ( module StringReExports
   , CodePoint()
@@ -36,12 +40,17 @@ import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
 
 
+-- | CodePoint is an Int bounded between 0 and 0x10FFFF, corresponding to
+-- | Unicode code points.
 newtype CodePoint = CodePoint Int
 
 derive instance eqCodePoint :: Eq CodePoint
 derive instance ordCodePoint :: Ord CodePoint
 derive instance newtypeCodePoint :: Newtype CodePoint _
 
+-- I would prefer that this smart constructor not need to exist and instead
+-- CodePoint just implements Enum, but the Enum module already depends on this
+-- one. To avoid the circular dependency, we just expose these two functions.
 codePointFromInt :: Int -> Maybe CodePoint
 codePointFromInt n | 0 <= n && n <= 0x10FFFF = Just (CodePoint n)
 codePointFromInt n = Nothing

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -1,4 +1,4 @@
-module CodePoints
+module Data.String.CodePoints
   ( module StringReExports
   , CodePoint()
   , codePointAt
@@ -25,14 +25,19 @@ import Data.Array as Array
 import Data.Char (toCharCode)
 import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
+import Data.Newtype (class Newtype)
 import Data.String as String
 import Data.String hiding (count, drop, dropWhile, indexOf, indexOf', lastIndexOf, lastIndexOf', length, singleton, splitAt, take, takeWhile, uncons) as StringReExports
 import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
-import Prelude ((&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
+import Prelude (class Eq, class Ord, (&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
 
 
 newtype CodePoint = CodePoint Int
+
+derive instance eqCodePoint :: Eq CodePoint
+derive instance ordCodePoint :: Ord CodePoint
+derive instance newtypeCodePoint :: Newtype CodePoint _
 
 codePointFromInt :: Int -> Maybe CodePoint
 codePointFromInt n | 0 <= n && n <= 0x10FFFF = Just (CodePoint n)

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -149,8 +149,8 @@ lastIndexOf p s = (\i -> length (String.take i s)) <$> String.lastIndexOf p s
 
 lastIndexOf' :: String.Pattern -> Int -> String -> Maybe Int
 lastIndexOf' p i s =
-  let s' = drop i s in
-  (\k -> i + length (String.take k s')) <$> String.lastIndexOf p s'
+  let i' = String.length (take i s) in
+  (\k -> length (String.take k s)) <$> String.lastIndexOf' p i' s
 
 
 length :: String -> Int

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -6,7 +6,7 @@ module CodePoints
   , codePointToInt
   --, contains
   , count
-  --, drop
+  , drop
   --, dropWhile
   --, indexOf
   --, indexOf'
@@ -20,7 +20,7 @@ module CodePoints
   --, splitAt
   --, stripPrefix
   --, stripSuffix
-  --, take
+  , take
   --, takeWhile
   --, uncons
   , toCodePointArray
@@ -33,7 +33,7 @@ import Data.String (toCharArray)
 import Data.Unfoldable (unfoldr)
 import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Tuple (Tuple(Tuple))
-import Data.Array (index, length, filter)
+import Data.Array as Array
 import Data.Char (toCharCode)
 
 newtype CodePoint = CodePoint Int
@@ -72,11 +72,24 @@ foreign import _codePointAt
   -> Maybe CodePoint
 
 codePointAtFallback :: Int -> String -> Maybe CodePoint
-codePointAtFallback n s = index (toCodePointArray s) n
+codePointAtFallback n s = Array.index (toCodePointArray s) n
 
 
 count :: (CodePoint -> Boolean) -> String -> Int
-count pred = length <<< filter pred <<< toCodePointArray
+count pred = Array.length <<< Array.filter pred <<< toCodePointArray
+
+
+drop :: Int -> String -> String
+drop n s = fromCodePointArray (Array.drop n (toCodePointArray s))
+
+
+take :: Int -> String -> String
+take = _take takeFallback
+
+foreign import _take :: (Int -> String -> String) -> Int -> String -> String
+
+takeFallback :: Int -> String -> String
+takeFallback n s = fromCodePointArray (Array.take n (toCodePointArray s))
 
 
 toCodePointArray :: String -> Array CodePoint
@@ -95,3 +108,6 @@ toCodePointArrayFallback s = unfoldr decode (fromFoldable (toCharCode <$> toChar
     = Just (Tuple (CodePoint (unsurrogate h l)) rest)
   decode (Cons c rest) = Just (Tuple (CodePoint c) rest)
   decode Nil = Nothing
+
+
+foreign import fromCodePointArray :: Array CodePoint -> String

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -27,6 +27,7 @@ import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Newtype (class Newtype)
 import Data.String as String
+import Data.String.Unsafe as Unsafe
 -- WARN: This list must be updated to re-export any exports added to Data.String. That makes me sad.
 import Data.String (Pattern(..), Replacement(..), charAt, charCodeAt, contains, fromCharArray, joinWith, localeCompare, null, replace, replaceAll, split, stripPrefix, stripSuffix, toChar, toCharArray, toLower, toUpper, trim) as StringReExports
 import Data.Tuple (Tuple(Tuple))
@@ -73,13 +74,11 @@ foreign import _unsafeCodePointAt0
   -> CodePoint
 
 unsafeCodePointAt0Fallback :: String -> CodePoint
-unsafeCodePointAt0Fallback s | String.length s == 1 = CodePoint (_unsafeCharCodeAt 0 s)
+unsafeCodePointAt0Fallback s | String.length s == 1 = CodePoint (Unsafe.charCodeAt 0 s)
 unsafeCodePointAt0Fallback s = CodePoint (((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000)
   where
-    lead = _unsafeCharCodeAt 0 s
-    trail = _unsafeCharCodeAt 1 s
-
-foreign import _unsafeCharCodeAt :: Int -> String -> Int
+    lead = Unsafe.charCodeAt 0 s
+    trail = Unsafe.charCodeAt 1 s
 
 
 codePointAt :: Int -> String -> Maybe CodePoint

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -31,7 +31,6 @@ import Data.Array as Array
 import Data.Char as Char
 import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
-import Data.Newtype (class Newtype)
 import Data.String as String
 import Data.String.Unsafe as Unsafe
 -- WARN: This list must be updated to re-export any exports added to Data.String. That makes me sad.
@@ -46,7 +45,6 @@ newtype CodePoint = CodePoint Int
 
 derive instance eqCodePoint :: Eq CodePoint
 derive instance ordCodePoint :: Ord CodePoint
-derive instance newtypeCodePoint :: Newtype CodePoint _
 
 -- I would prefer that this smart constructor not need to exist and instead
 -- CodePoint just implements Enum, but the Enum module already depends on this

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -27,7 +27,8 @@ import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.Newtype (class Newtype)
 import Data.String as String
-import Data.String hiding (count, drop, dropWhile, indexOf, indexOf', lastIndexOf, lastIndexOf', length, singleton, splitAt, take, takeWhile, uncons) as StringReExports
+-- WARN: This list must be updated to re-export any exports added to Data.String. That makes me sad.
+import Data.String (Pattern(..), Replacement(..), charAt, charCodeAt, contains, fromCharArray, joinWith, localeCompare, null, replace, replaceAll, split, stripPrefix, stripSuffix, toChar, toCharArray, toLower, toUpper, trim) as StringReExports
 import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
 import Prelude (class Eq, class Ord, (&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -17,7 +17,7 @@ module CodePoints
   --, replaceAll
   , singleton
   --, split
-  --, splitAt
+  , splitAt
   --, stripPrefix
   --, stripSuffix
   , take
@@ -27,7 +27,7 @@ module CodePoints
   --, fromCodePointArray
   ) where
 
-import Prelude ((&&), (*), (+), (-), (<$>), (<=), (<<<))
+import Prelude ((&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.String (toCharArray)
 import Data.Unfoldable (unfoldr)
@@ -88,6 +88,17 @@ length = Array.length <<< toCodePointArray
 
 
 foreign import singleton :: CodePoint -> String
+
+
+splitAt :: Int -> String -> Maybe { before :: String, after :: String }
+splitAt i s =
+  let cps = toCodePointArray s in
+  if i < 0 || Array.length cps <= i
+    then Nothing
+    else Just {
+        before: fromCodePointArray (Array.take i cps),
+        after: fromCodePointArray (Array.drop i cps)
+      }
 
 
 take :: Int -> String -> String

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -138,14 +138,14 @@ countTail p s accum = case uncons s of
 
 -- | Drops the given number of code points from the beginning of the string. If
 -- | the string does not have that many code points, returns the empty string.
--- | Operates in space and time linear to the length of the string.
+-- | Operates in constant space and in time linear to the given number.
 drop :: Int -> String -> String
 drop n s = String.drop (String.length (take n s)) s
 
 
 -- | Drops the leading sequence of code points which all match the given
--- | predicate from the string. Operates in space and time linear to the
--- | length of the string.
+-- | predicate from the string. Operates in constant space and in time linear
+-- | to the length of the string.
 dropWhile :: (CodePoint -> Boolean) -> String -> String
 dropWhile p s = drop (count p s) s
 
@@ -230,8 +230,8 @@ splitAt i s =
 
 -- | Returns a string containing the given number of code points from the
 -- | beginning of the given string. If the string does not have that many code
--- | points, returns the empty string. Operates in space and time linear to the
--- | given number.
+-- | points, returns the empty string. Operates in constant space and in time
+-- | linear to the given number.
 take :: Int -> String -> String
 take = _take takeFallback
 
@@ -245,8 +245,8 @@ takeFallback n s = case uncons s of
 
 
 -- | Returns a string containing the leading sequence of code points which all
--- | match the given predicate from the string. Operates in space and time
--- | linear to the length of the string.
+-- | match the given predicate from the string. Operates in constant space and
+-- | in time linear to the length of the string.
 takeWhile :: (CodePoint -> Boolean) -> String -> String
 takeWhile p s = take (count p s) s
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -62,7 +62,7 @@ codePointFromSurrogatePair lead trail | isLead lead && isTrail trail =
 codePointFromSurrogatePair _ _ = Nothing
 
 unsurrogate :: Int -> Int -> CodePoint
-unsurrogate h l = CodePoint ((h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000)
+unsurrogate lead trail = CodePoint ((lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000)
 
 isLead :: Int -> Boolean
 isLead cu = 0xD800 <= cu && cu <= 0xDBFF
@@ -83,7 +83,7 @@ foreign import _unsafeCodePointAt0
 
 unsafeCodePointAt0Fallback :: String -> CodePoint
 unsafeCodePointAt0Fallback s | String.length s == 1 = CodePoint (Unsafe.charCodeAt 0 s)
-unsafeCodePointAt0Fallback s = CodePoint (((lead - 0xD800) * 0x400) + (trail - 0xDC00) + 0x10000)
+unsafeCodePointAt0Fallback s = CodePoint (unsurrogate lead trail)
   where
     lead = Unsafe.charCodeAt 0 s
     trail = Unsafe.charCodeAt 1 s

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -12,7 +12,7 @@ module CodePoints
   --, indexOf'
   --, lastIndexOf
   --, lastIndexOf'
-  --, length
+  , length
   --, replace
   --, replaceAll
   --, singleton
@@ -81,6 +81,10 @@ count pred = Array.length <<< Array.filter pred <<< toCodePointArray
 
 drop :: Int -> String -> String
 drop n s = fromCodePointArray (Array.drop n (toCodePointArray s))
+
+
+length :: String -> Int
+length = Array.length <<< toCodePointArray
 
 
 take :: Int -> String -> String

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -266,7 +266,7 @@ toCodePointArrayFallback :: String -> Array CodePoint
 toCodePointArrayFallback s = unfoldr unconsButWithTuple s
 
 unconsButWithTuple :: String -> Maybe (Tuple CodePoint String)
-unconsButWithTuple s' = (\{ head, tail } -> Tuple head tail) <$> uncons s'
+unconsButWithTuple s = (\{ head, tail } -> Tuple head tail) <$> uncons s
 
 
 -- | Returns a record with the first code point and the remaining code points

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -129,11 +129,11 @@ foreign import _count
 
 countFallback :: (CodePoint -> Boolean) -> String -> Int
 countFallback p s = countTail p s 0
-  where
-  countTail :: (CodePoint -> Boolean) -> String -> Int -> Int
-  countTail p' s' accum = case uncons s' of
-    Just { head, tail } -> if p' head then countTail p' tail (accum + 1) else accum
-    _ -> accum
+
+countTail :: (CodePoint -> Boolean) -> String -> Int -> Int
+countTail p s accum = case uncons s of
+  Just { head, tail } -> if p head then countTail p tail (accum + 1) else accum
+  _ -> accum
 
 
 -- | Drops the given number of code points from the beginning of the string. If
@@ -263,10 +263,10 @@ foreign import _toCodePointArray
   -> Array CodePoint
 
 toCodePointArrayFallback :: String -> Array CodePoint
-toCodePointArrayFallback s = unfoldr decode s
-  where
-  decode :: String -> Maybe (Tuple CodePoint String)
-  decode s' = (\{ head, tail } -> Tuple head tail) <$> uncons s'
+toCodePointArrayFallback s = unfoldr unconsButWithTuple s
+
+unconsButWithTuple :: String -> Maybe (Tuple CodePoint String)
+unconsButWithTuple s' = (\{ head, tail } -> Tuple head tail) <$> uncons s'
 
 
 -- | Returns a record with the first code point and the remaining code points

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -1,0 +1,66 @@
+module CodePoints
+  ( CodePoint()
+  --, Pattern()
+  --, codePointAt
+  --, fromCodePointArray
+  --, contains
+  --, indexOf
+  --, indexOf'
+  --, lastIndexOf
+  --, lastIndexOf'
+  --, uncons
+  --, length
+  --, singleton
+  --, replace
+  --, replaceAll
+  --, take
+  --, takeWhile
+  --, drop
+  --, dropWhile
+  --, stripPrefix
+  --, stripSuffix
+  --, count
+  --, split
+  --, splitAt
+  --, toCodePointArray
+  ) where
+
+import Prelude ((&&), (<=), (*), (+), (-))
+import Data.Maybe (Maybe(Just, Nothing))
+
+newtype CodePoint = CodePoint Int
+
+codePointFromInt :: Int -> Maybe CodePoint
+codePointFromInt n | 0 <= n && n <= 0x10FFFF = Just (CodePoint n)
+codePointFromInt n = Nothing
+
+codePointToInt :: CodePoint -> Int
+codePointToInt (CodePoint n) = n
+
+codePointFromSurrogatePair :: Int -> Int -> Maybe CodePoint
+codePointFromSurrogatePair lead trail | isLead lead && isTrail trail
+  = Just (CodePoint (unsurrogate lead trail))
+    where unsurrogate h l = (h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000
+codePointFromSurrogatePair _ _ = Nothing
+
+isLead :: Int -> Boolean
+isLead cu = 0xD800 <= cu && cu <= 0xDBFF
+
+isTrail :: Int -> Boolean
+isTrail cu = 0xDC00 <= cu && cu <= 0xDFFF
+
+codePointAt :: Int -> String -> Maybe CodePoint
+codePointAt = _codePointAt (Just . CodePoint) Nothing
+
+foreign import _codePointAt
+  :: (Int -> String -> Maybe CodePoint)
+  -> (forall a. a -> Maybe a)
+  -> (forall a. Maybe a)
+  -> Int
+  -> String
+  -> Maybe CodePoint
+
+codePointAtFallback :: Int -> String -> Maybe CodePoint
+codePointAtFallback n s = CodePoint <$> index (toCodePointArray s) n
+
+foreign import _toCodePointArray :: String -> Array CodePoint

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -2,27 +2,29 @@ module CodePoints
   ( CodePoint()
   --, Pattern()
   , codePointAt
-  --, fromCodePointArray
+  , codePointFromInt
+  , codePointToInt
   --, contains
+  --, count
+  --, drop
+  --, dropWhile
   --, indexOf
   --, indexOf'
   --, lastIndexOf
   --, lastIndexOf'
-  --, uncons
   --, length
-  --, singleton
   --, replace
   --, replaceAll
-  --, take
-  --, takeWhile
-  --, drop
-  --, dropWhile
-  --, stripPrefix
-  --, stripSuffix
-  --, count
+  --, singleton
   --, split
   --, splitAt
+  --, stripPrefix
+  --, stripSuffix
+  --, take
+  --, takeWhile
+  --, uncons
   , toCodePointArray
+  --, fromCodePointArray
   ) where
 
 import Prelude ((&&), (*), (+), (-), (<$>), (<=))
@@ -57,6 +59,7 @@ isLead cu = 0xD800 <= cu && cu <= 0xDBFF
 isTrail :: Int -> Boolean
 isTrail cu = 0xDC00 <= cu && cu <= 0xDFFF
 
+
 codePointAt :: Int -> String -> Maybe CodePoint
 codePointAt = _codePointAt codePointAtFallback Just Nothing
 
@@ -70,6 +73,7 @@ foreign import _codePointAt
 
 codePointAtFallback :: Int -> String -> Maybe CodePoint
 codePointAtFallback n s = index (toCodePointArray s) n
+
 
 toCodePointArray :: String -> Array CodePoint
 toCodePointArray = _toCodePointArray toCodePointArrayFallback

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -104,7 +104,9 @@ indexOf p s = (\i -> length (String.take i s)) <$> String.indexOf p s
 
 
 indexOf' :: String.Pattern -> Int -> String -> Maybe Int
-indexOf' p i s = (\k -> length (String.take k s)) <$> String.indexOf' p i s
+indexOf' p i s =
+  let s' = drop i s in
+  (\k -> i + length (String.take k s')) <$> String.indexOf p s'
 
 
 lastIndexOf :: String.Pattern -> String -> Maybe Int
@@ -112,7 +114,9 @@ lastIndexOf p s = (\i -> length (String.take i s)) <$> String.lastIndexOf p s
 
 
 lastIndexOf' :: String.Pattern -> Int -> String -> Maybe Int
-lastIndexOf' p i s = (\k -> length (String.take k s)) <$> String.lastIndexOf' p i s
+lastIndexOf' p i s =
+  let s' = drop i s in
+  (\k -> i + length (String.take k s')) <$> String.lastIndexOf p s'
 
 
 length :: String -> Int
@@ -125,7 +129,7 @@ foreign import singleton :: CodePoint -> String
 splitAt :: Int -> String -> Maybe { before :: String, after :: String }
 splitAt i s =
   let cps = toCodePointArray s in
-  if i < 0 || Array.length cps <= i
+  if i < 0 || Array.length cps < i
     then Nothing
     else Just {
         before: fromCodePointArray (Array.take i cps),

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -6,7 +6,7 @@ module CodePoints
   , codePointToInt
   , count
   , drop
-  --, dropWhile
+  , dropWhile
   , fromCodePointArray
   --, indexOf
   --, indexOf'
@@ -16,7 +16,7 @@ module CodePoints
   , singleton
   , splitAt
   , take
-  --, takeWhile
+  , takeWhile
   , toCodePointArray
   , uncons
   ) where
@@ -31,6 +31,7 @@ import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
 import Prelude ((&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
 
+
 newtype CodePoint = CodePoint Int
 
 codePointFromInt :: Int -> Maybe CodePoint
@@ -42,11 +43,11 @@ codePointToInt (CodePoint n) = n
 
 codePointFromSurrogatePair :: Int -> Int -> Maybe CodePoint
 codePointFromSurrogatePair lead trail | isLead lead && isTrail trail
-  = Just (CodePoint (unsurrogate lead trail))
+  = Just (unsurrogate lead trail)
 codePointFromSurrogatePair _ _ = Nothing
 
-unsurrogate :: Int -> Int -> Int
-unsurrogate h l = (h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000
+unsurrogate :: Int -> Int -> CodePoint
+unsurrogate h l = CodePoint ((h - 0xD800) * 0x400 + (l - 0xDC00) + 0x10000)
 
 isLead :: Int -> Boolean
 isLead cu = 0xD800 <= cu && cu <= 0xDBFF
@@ -71,11 +72,23 @@ codePointAtFallback n s = Array.index (toCodePointArray s) n
 
 
 count :: (CodePoint -> Boolean) -> String -> Int
-count pred = Array.length <<< Array.filter pred <<< toCodePointArray
+count = _count isLead isTrail unsurrogate
+
+foreign import _count
+  :: (Int -> Boolean)
+  -> (Int -> Boolean)
+  -> (Int -> Int -> CodePoint)
+  -> (CodePoint -> Boolean)
+  -> String
+  -> Int
 
 
 drop :: Int -> String -> String
 drop n s = fromCodePointArray (Array.drop n (toCodePointArray s))
+
+
+dropWhile :: (CodePoint -> Boolean) -> String -> String
+dropWhile p s = drop (count p s) s
 
 
 foreign import fromCodePointArray :: Array CodePoint -> String
@@ -108,6 +121,10 @@ takeFallback :: Int -> String -> String
 takeFallback n s = fromCodePointArray (Array.take n (toCodePointArray s))
 
 
+takeWhile :: (CodePoint -> Boolean) -> String -> String
+takeWhile p s = take (count p s) s
+
+
 toCodePointArray :: String -> Array CodePoint
 toCodePointArray = _toCodePointArray toCodePointArrayFallback
 
@@ -121,7 +138,7 @@ toCodePointArrayFallback s = unfoldr decode (fromFoldable (toCharCode <$> toChar
   where
   decode :: List Int -> Maybe (Tuple CodePoint (List Int))
   decode (Cons h (Cons l rest)) | isLead h && isTrail l
-    = Just (Tuple (CodePoint (unsurrogate h l)) rest)
+    = Just (Tuple (unsurrogate h l) rest)
   decode (Cons c rest) = Just (Tuple (CodePoint c) rest)
   decode Nil = Nothing
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -5,7 +5,7 @@ module CodePoints
   , codePointFromInt
   , codePointToInt
   --, contains
-  --, count
+  , count
   --, drop
   --, dropWhile
   --, indexOf
@@ -27,13 +27,13 @@ module CodePoints
   --, fromCodePointArray
   ) where
 
-import Prelude ((&&), (*), (+), (-), (<$>), (<=))
+import Prelude ((&&), (*), (+), (-), (<$>), (<=), (<<<))
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.String (toCharArray)
 import Data.Unfoldable (unfoldr)
 import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Tuple (Tuple(Tuple))
-import Data.Array (index)
+import Data.Array (index, length, filter)
 import Data.Char (toCharCode)
 
 newtype CodePoint = CodePoint Int
@@ -73,6 +73,10 @@ foreign import _codePointAt
 
 codePointAtFallback :: Int -> String -> Maybe CodePoint
 codePointAtFallback n s = index (toCodePointArray s) n
+
+
+count :: (CodePoint -> Boolean) -> String -> Int
+count pred = length <<< filter pred <<< toCodePointArray
 
 
 toCodePointArray :: String -> Array CodePoint

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -56,11 +56,6 @@ codePointFromInt n = Nothing
 codePointToInt :: CodePoint -> Int
 codePointToInt (CodePoint n) = n
 
-codePointFromSurrogatePair :: Int -> Int -> Maybe CodePoint
-codePointFromSurrogatePair lead trail | isLead lead && isTrail trail =
-  Just (unsurrogate lead trail)
-codePointFromSurrogatePair _ _ = Nothing
-
 unsurrogate :: Int -> Int -> CodePoint
 unsurrogate lead trail = CodePoint ((lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000)
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -8,10 +8,10 @@ module CodePoints
   , drop
   , dropWhile
   , fromCodePointArray
-  --, indexOf
-  --, indexOf'
-  --, lastIndexOf
-  --, lastIndexOf'
+  , indexOf
+  , indexOf'
+  , lastIndexOf
+  , lastIndexOf'
   , length
   , singleton
   , splitAt
@@ -25,7 +25,7 @@ import Data.Array as Array
 import Data.Char (toCharCode)
 import Data.List (List(Cons, Nil), fromFoldable)
 import Data.Maybe (Maybe(Just, Nothing))
-import Data.String (toCharArray)
+import Data.String as String
 import Data.String hiding (count, drop, dropWhile, indexOf, indexOf', lastIndexOf, lastIndexOf', length, singleton, splitAt, take, takeWhile, uncons) as StringReExports
 import Data.Tuple (Tuple(Tuple))
 import Data.Unfoldable (unfoldr)
@@ -94,6 +94,22 @@ dropWhile p s = drop (count p s) s
 foreign import fromCodePointArray :: Array CodePoint -> String
 
 
+indexOf :: String.Pattern -> String -> Maybe Int
+indexOf p s = (\i -> length (String.take i s)) <$> String.indexOf p s
+
+
+indexOf' :: String.Pattern -> Int -> String -> Maybe Int
+indexOf' p i s = (\k -> length (String.take k s)) <$> String.indexOf' p i s
+
+
+lastIndexOf :: String.Pattern -> String -> Maybe Int
+lastIndexOf p s = (\i -> length (String.take i s)) <$> String.lastIndexOf p s
+
+
+lastIndexOf' :: String.Pattern -> Int -> String -> Maybe Int
+lastIndexOf' p i s = (\k -> length (String.take k s)) <$> String.lastIndexOf' p i s
+
+
 length :: String -> Int
 length = Array.length <<< toCodePointArray
 
@@ -134,7 +150,7 @@ foreign import _toCodePointArray
   -> Array CodePoint
 
 toCodePointArrayFallback :: String -> Array CodePoint
-toCodePointArrayFallback s = unfoldr decode (fromFoldable (toCharCode <$> toCharArray s))
+toCodePointArrayFallback s = unfoldr decode (fromFoldable (toCharCode <$> String.toCharArray s))
   where
   decode :: List Int -> Maybe (Tuple CodePoint (List Int))
   decode (Cons h (Cons l rest)) | isLead h && isTrail l

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -1,40 +1,36 @@
 module CodePoints
   ( CodePoint()
-  --, Pattern()
   , codePointAt
   , codePointFromInt
   , codePointToInt
-  --, contains
   , count
   , drop
   --, dropWhile
+  , fromCodePointArray
   --, indexOf
   --, indexOf'
   --, lastIndexOf
   --, lastIndexOf'
   , length
-  --, replace
-  --, replaceAll
   , singleton
-  --, split
   , splitAt
-  --, stripPrefix
-  --, stripSuffix
   , take
   --, takeWhile
   --, uncons
   , toCodePointArray
-  --, fromCodePointArray
+
+  , module StringReExports
   ) where
 
-import Prelude ((&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
-import Data.Maybe (Maybe(Just, Nothing))
-import Data.String (toCharArray)
-import Data.Unfoldable (unfoldr)
-import Data.List (List(Cons, Nil), fromFoldable)
-import Data.Tuple (Tuple(Tuple))
 import Data.Array as Array
 import Data.Char (toCharCode)
+import Data.List (List(Cons, Nil), fromFoldable)
+import Data.Maybe (Maybe(Just, Nothing))
+import Data.String (toCharArray)
+import Data.String hiding (count, drop, dropWhile, indexOf, indexOf', lastIndexOf, lastIndexOf', length, singleton, splitAt, take, takeWhile, uncons) as StringReExports
+import Data.Tuple (Tuple(Tuple))
+import Data.Unfoldable (unfoldr)
+import Prelude ((&&), (||), (*), (+), (-), (<$>), (<), (<=), (<<<))
 
 newtype CodePoint = CodePoint Int
 

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -46,8 +46,8 @@ testStringCodePoints = do
   assert $ drop 8 str == ""
 
   log "dropWhile"
-  assert $ dropWhile (\c -> true) str == ""
-  assert $ dropWhile (\c -> false) str == str
+  assert $ dropWhile (\_ -> true) str == ""
+  assert $ dropWhile (\_ -> false) str == str
   assert $ dropWhile (\c -> codePointToInt c < 0xFFFF) str == "\x16805\x16A06\&z"
   assert $ dropWhile (\c -> codePointToInt c < 0xDC00) str == "\xDC00\xD800\xD800\x16805\x16A06\&z"
 
@@ -161,8 +161,8 @@ testStringCodePoints = do
   assert $ take 8 str == str
 
   log "takeWhile"
-  assert $ takeWhile (\c -> true) str == str
-  assert $ takeWhile (\c -> false) str == ""
+  assert $ takeWhile (\_ -> true) str == str
+  assert $ takeWhile (\_ -> false) str == ""
   assert $ takeWhile (\c -> codePointToInt c < 0xFFFF) str == "a\xDC00\xD800\xD800"
   assert $ takeWhile (\c -> codePointToInt c < 0xDC00) str == "a"
 

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -1,6 +1,6 @@
 module Test.Data.String.CodePoints (testStringCodePoints) where
 
-import Prelude (Unit, discard, negate, (==), ($), (&&), (<), (<$>))
+import Prelude
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -1,6 +1,6 @@
 module Test.Data.String.CodePoints (testStringCodePoints) where
 
-import Prelude (Unit, Ordering(..), (==), ($), discard, negate, not, (/=), (&&), (<))
+import Prelude (Unit, discard, negate, (==), ($), (&&), (<), (<$>))
 
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
@@ -54,6 +54,7 @@ testStringCodePoints = do
   log "indexOf"
   assert $ indexOf (Pattern "") "" == Just 0
   assert $ indexOf (Pattern "") str == Just 0
+  assert $ indexOf (Pattern str) str == Just 0
   assert $ indexOf (Pattern "a") str == Just 0
   assert $ indexOf (Pattern "\xDC00\xD800\xD800") str == Just 1
   assert $ indexOf (Pattern "\xD800") str == Just 2
@@ -71,73 +72,119 @@ testStringCodePoints = do
   -- I vote we just delete the test. Passing surrogate halves to the CodePoints functions should not be supported.
   assert $ indexOf (Pattern "\xDC05") str == Just 5
 
---  log "singleton"
---  assert $ singleton 'a' == "a"
---
---  log "takeWhile"
---  assert $ takeWhile (\c -> true) "abc" == "abc"
---  assert $ takeWhile (\c -> false) "abc" == ""
---  assert $ takeWhile (\c -> c /= 'b') "aabbcc" == "aa"
---
---  log "indexOf'"
---  assert $ indexOf' (Pattern "") 0 "" == Just 0
---  assert $ indexOf' (Pattern "") (-1) "ab" == Nothing
---  assert $ indexOf' (Pattern "") 0 "ab" == Just 0
---  assert $ indexOf' (Pattern "") 1 "ab" == Just 1
---  assert $ indexOf' (Pattern "") 2 "ab" == Just 2
---  assert $ indexOf' (Pattern "") 3 "ab" == Nothing
---  assert $ indexOf' (Pattern "bc") 0 "abcd" == Just 1
---  assert $ indexOf' (Pattern "bc") 1 "abcd" == Just 1
---  assert $ indexOf' (Pattern "bc") 2 "abcd" == Nothing
---  assert $ indexOf' (Pattern "cb") 0 "abcd" == Nothing
---
---  log "lastIndexOf"
---  assert $ lastIndexOf (Pattern "") "" == Just 0
---  assert $ lastIndexOf (Pattern "") "abcd" == Just 4
---  assert $ lastIndexOf (Pattern "bc") "abcd" == Just 1
---  assert $ lastIndexOf (Pattern "cb") "abcd" == Nothing
---
---  log "lastIndexOf'"
---  assert $ lastIndexOf' (Pattern "") 0 "" == Just 0
---  assert $ lastIndexOf' (Pattern "") (-1) "ab" == Nothing
---  assert $ lastIndexOf' (Pattern "") 0 "ab" == Just 0
---  assert $ lastIndexOf' (Pattern "") 1 "ab" == Just 1
---  assert $ lastIndexOf' (Pattern "") 2 "ab" == Just 2
---  assert $ lastIndexOf' (Pattern "") 3 "ab" == Nothing
---  assert $ lastIndexOf' (Pattern "bc") 0 "abcd" == Nothing
---  assert $ lastIndexOf' (Pattern "bc") 1 "abcd" == Just 1
---  assert $ lastIndexOf' (Pattern "bc") 2 "abcd" == Just 1
---  assert $ lastIndexOf' (Pattern "cb") 0 "abcd" == Nothing
---
---  log "length"
---  assert $ length "" == 0
---  assert $ length "a" == 1
---  assert $ length "ab" == 2
---
---  log "take"
---  assert $ take 0 "ab" == ""
---  assert $ take 1 "ab" == "a"
---  assert $ take 2 "ab" == "ab"
---  assert $ take 3 "ab" == "ab"
---  assert $ take (-1) "ab" == ""
---
---  log "count"
---  assert $ count (_ == 'a') "" == 0
---  assert $ count (_ == 'a') "ab" == 1
---  assert $ count (_ == 'a') "aaab" == 3
---  assert $ count (_ == 'a') "abaa" == 1
---
---  log "splitAt"
---  let testSplitAt i str res =
---        assert $ case splitAt i str of
---          Nothing ->
---            isNothing res
---          Just { before, after } ->
---            maybe false (\r ->
---              r.before == before && r.after == after) res
---
---  testSplitAt 1 "" Nothing
---  testSplitAt 0 "a" $ Just {before: "", after: "a"}
---  testSplitAt 1 "ab" $ Just {before: "a", after: "b"}
---  testSplitAt 3 "aabcc" $ Just {before: "aab", after: "cc"}
---  testSplitAt (-1) "abc" $ Nothing
+  log "indexOf'"
+  assert $ indexOf' (Pattern "") 0 "" == Just 0
+  assert $ indexOf' (Pattern str) 0 str == Just 0
+  assert $ indexOf' (Pattern str) 1 str == Nothing
+  assert $ indexOf' (Pattern "a") 0 str == Just 0
+  assert $ indexOf' (Pattern "a") 1 str == Nothing
+  assert $ indexOf' (Pattern "z") 0 str == Just 6
+  assert $ indexOf' (Pattern "z") 1 str == Just 6
+  assert $ indexOf' (Pattern "z") 2 str == Just 6
+  assert $ indexOf' (Pattern "z") 3 str == Just 6
+  assert $ indexOf' (Pattern "z") 4 str == Just 6
+  assert $ indexOf' (Pattern "z") 5 str == Just 6
+  assert $ indexOf' (Pattern "z") 6 str == Just 6
+  assert $ indexOf' (Pattern "z") 7 str == Nothing
+
+  log "lastIndexOf"
+  assert $ lastIndexOf (Pattern "") "" == Just 0
+  assert $ lastIndexOf (Pattern "") str == Just 7
+  assert $ lastIndexOf (Pattern str) str == Just 0
+  assert $ lastIndexOf (Pattern "a") str == Just 0
+  assert $ lastIndexOf (Pattern "\xDC00\xD800\xD800") str == Just 1
+  assert $ lastIndexOf (Pattern "\xD800") str == Just 3
+  assert $ lastIndexOf (Pattern "\xD800\xD800") str == Just 2
+  assert $ lastIndexOf (Pattern "\xD800\xD81A") str == Just 3
+  assert $ lastIndexOf (Pattern "\xD800\x16805") str == Just 3
+  assert $ lastIndexOf (Pattern "\x16805") str == Just 4
+  assert $ lastIndexOf (Pattern "\x16A06") str == Just 5
+  assert $ lastIndexOf (Pattern "z") str == Just 6
+  assert $ lastIndexOf (Pattern "\0") str == Nothing
+  assert $ lastIndexOf (Pattern "\xD81A") str == Just 5
+
+  log "lastIndexOf'"
+  assert $ lastIndexOf' (Pattern "") 0 "" == Just 0
+  assert $ lastIndexOf' (Pattern str) 0 str == Just 0
+  assert $ lastIndexOf' (Pattern str) 1 str == Nothing
+  assert $ lastIndexOf' (Pattern "a") 0 str == Just 0
+  assert $ lastIndexOf' (Pattern "a") 1 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 0 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 1 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 2 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 3 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 4 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 5 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 6 str == Just 6
+  assert $ lastIndexOf' (Pattern "z") 7 str == Nothing
+
+  log "length"
+  assert $ length "" == 0
+  assert $ length "a" == 1
+  assert $ length "ab" == 2
+  assert $ length str == 7
+
+  log "singleton"
+  assert $ (singleton <$> codePointFromInt 0x30) == Just "0"
+  assert $ (singleton <$> codePointFromInt 0x16805) == Just "\x16805"
+
+  log "splitAt"
+  let testSplitAt i s res =
+        assert $ case splitAt i s of
+          Nothing ->
+            isNothing res
+          Just { before, after } ->
+            maybe false (\r ->
+              r.before == before && r.after == after) res
+
+  testSplitAt 0 "" $ Just {before: "", after: ""}
+  testSplitAt 1 "" Nothing
+  testSplitAt 0 "a" $ Just {before: "", after: "a"}
+  testSplitAt 1 "ab" $ Just {before: "a", after: "b"}
+  testSplitAt 3 "aabcc" $ Just {before: "aab", after: "cc"}
+  testSplitAt (-1) "abc" $ Nothing
+  testSplitAt 0 str $ Just {before: "", after: str}
+  testSplitAt 1 str $ Just {before: "a", after: "\xDC00\xD800\xD800\x16805\x16A06\&z"}
+  testSplitAt 2 str $ Just {before: "a\xDC00", after: "\xD800\xD800\x16805\x16A06\&z"}
+  testSplitAt 3 str $ Just {before: "a\xDC00\xD800", after: "\xD800\x16805\x16A06\&z"}
+  testSplitAt 4 str $ Just {before: "a\xDC00\xD800\xD800", after: "\x16805\x16A06\&z"}
+  testSplitAt 5 str $ Just {before: "a\xDC00\xD800\xD800\x16805", after: "\x16A06\&z"}
+  testSplitAt 6 str $ Just {before: "a\xDC00\xD800\xD800\x16805\x16A06", after: "z"}
+  testSplitAt 7 str $ Just {before: str, after: ""}
+  testSplitAt 8 str $ Nothing
+
+  log "take"
+  assert $ take (-1) str == ""
+  assert $ take 0 str == ""
+  assert $ take 1 str == "a"
+  assert $ take 2 str == "a\xDC00"
+  assert $ take 3 str == "a\xDC00\xD800"
+  assert $ take 4 str == "a\xDC00\xD800\xD800"
+  assert $ take 5 str == "a\xDC00\xD800\xD800\x16805"
+  assert $ take 6 str == "a\xDC00\xD800\xD800\x16805\x16A06"
+  assert $ take 7 str == str
+  assert $ take 8 str == str
+
+  log "takeWhile"
+  assert $ takeWhile (\c -> true) str == str
+  assert $ takeWhile (\c -> false) str == ""
+  assert $ takeWhile (\c -> codePointToInt c < 0xFFFF) str == "a\xDC00\xD800\xD800"
+  assert $ takeWhile (\c -> codePointToInt c < 0xDC00) str == "a"
+
+  log "uncons"
+  let testUncons s res =
+        assert $ case uncons s of
+          Nothing ->
+            isNothing res
+          Just { head, tail } ->
+            maybe false (\r ->
+              r.head == codePointToInt head && r.tail == tail) res
+
+  testUncons str $ Just {head: 0x61, tail:  "\xDC00\xD800\xD800\x16805\x16A06\&z"}
+  testUncons (drop 1 str) $ Just {head: 0xDC00, tail: "\xD800\xD800\x16805\x16A06\&z"}
+  testUncons (drop 2 str) $ Just {head: 0xD800, tail: "\xD800\x16805\x16A06\&z"}
+  testUncons (drop 3 str) $ Just {head: 0xD800, tail: "\x16805\x16A06\&z"}
+  testUncons (drop 4 str) $ Just {head: 0x16805, tail: "\x16A06\&z"}
+  testUncons (drop 5 str) $ Just {head: 0x16A06, tail: "z"}
+  testUncons (drop 6 str) $ Just {head: 0x7A, tail: ""}
+  testUncons "" Nothing

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -66,11 +66,6 @@ testStringCodePoints = do
   assert $ indexOf (Pattern "z") str == Just 6
   assert $ indexOf (Pattern "\0") str == Nothing
   assert $ indexOf (Pattern "\xD81A") str == Just 4
-  -- TODO: Should this be Nothing? It matches the trail surrogate of a surrogate pair.
-  -- It'd be nice if (drop (indexOf pattern str) str) was guaranteed to start with pattern.
-  -- If we change this, we'll also need to add a matching contains implementation to the CodePoints module.
-  -- I vote we just delete the test. Passing surrogate halves to the CodePoints functions should not be supported.
-  assert $ indexOf (Pattern "\xDC05") str == Just 5
 
   log "indexOf'"
   assert $ indexOf' (Pattern "") 0 "" == Just 0

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -1,0 +1,143 @@
+module Test.Data.String.CodePoints (testStringCodePoints) where
+
+import Prelude (Unit, Ordering(..), (==), ($), discard, negate, not, (/=), (&&), (<))
+
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+
+import Data.Maybe (Maybe(..), isNothing, maybe)
+import Data.String.CodePoints
+
+import Test.Assert (ASSERT, assert)
+
+str :: String
+str = "a\xDC00\xD800\xD800\x16805\x16A06\&z"
+
+testStringCodePoints :: forall eff. Eff (console :: CONSOLE, assert :: ASSERT | eff) Unit
+testStringCodePoints = do
+  log "codePointAt"
+  assert $ codePointAt (-1) str == Nothing
+  assert $ codePointAt 0 str == (codePointFromInt 0x61)
+  assert $ codePointAt 1 str == (codePointFromInt 0xDC00)
+  assert $ codePointAt 2 str == (codePointFromInt 0xD800)
+  assert $ codePointAt 3 str == (codePointFromInt 0xD800)
+  assert $ codePointAt 4 str == (codePointFromInt 0x16805)
+  assert $ codePointAt 5 str == (codePointFromInt 0x16A06)
+  assert $ codePointAt 6 str == (codePointFromInt 0x7A)
+  assert $ codePointAt 7 str == Nothing
+
+  log "count"
+  assert $ count (\_ -> true) "" == 0
+  assert $ count (\_ -> false) str == 0
+  assert $ count (\_ -> true) str == 7
+  assert $ count (\x -> codePointToInt x < 0xFFFF) str == 4
+  assert $ count (\x -> codePointToInt x < 0xDC00) str == 1
+
+  log "drop"
+  assert $ drop (-1) str == str
+  assert $ drop 0 str == str
+  assert $ drop 1 str == "\xDC00\xD800\xD800\x16805\x16A06\&z"
+  assert $ drop 2 str == "\xD800\xD800\x16805\x16A06\&z"
+  assert $ drop 3 str == "\xD800\x16805\x16A06\&z"
+  assert $ drop 4 str == "\x16805\x16A06\&z"
+  assert $ drop 5 str == "\x16A06\&z"
+  assert $ drop 6 str == "z"
+  assert $ drop 7 str == ""
+  assert $ drop 8 str == ""
+
+  log "dropWhile"
+  assert $ dropWhile (\c -> true) str == ""
+  assert $ dropWhile (\c -> false) str == str
+  assert $ dropWhile (\c -> codePointToInt c < 0xFFFF) str == "\x16805\x16A06\&z"
+  assert $ dropWhile (\c -> codePointToInt c < 0xDC00) str == "\xDC00\xD800\xD800\x16805\x16A06\&z"
+
+  log "indexOf"
+  assert $ indexOf (Pattern "") "" == Just 0
+  assert $ indexOf (Pattern "") str == Just 0
+  assert $ indexOf (Pattern "a") str == Just 0
+  assert $ indexOf (Pattern "\xDC00\xD800\xD800") str == Just 1
+  assert $ indexOf (Pattern "\xD800") str == Just 2
+  assert $ indexOf (Pattern "\xD800\xD800") str == Just 2
+  assert $ indexOf (Pattern "\xD800\xD81A") str == Just 3
+  assert $ indexOf (Pattern "\xD800\x16805") str == Just 3
+  assert $ indexOf (Pattern "\x16805") str == Just 4
+  assert $ indexOf (Pattern "\x16A06") str == Just 5
+  assert $ indexOf (Pattern "z") str == Just 6
+  assert $ indexOf (Pattern "\0") str == Nothing
+  assert $ indexOf (Pattern "\xD81A") str == Just 4
+  -- TODO: Should this be Nothing? It matches the trail surrogate of a surrogate pair.
+  -- It'd be nice if (drop (indexOf pattern str) str) was guaranteed to start with pattern.
+  -- If we change this, we'll also need to add a matching contains implementation to the CodePoints module.
+  -- I vote we just delete the test. Passing surrogate halves to the CodePoints functions should not be supported.
+  assert $ indexOf (Pattern "\xDC05") str == Just 5
+
+--  log "singleton"
+--  assert $ singleton 'a' == "a"
+--
+--  log "takeWhile"
+--  assert $ takeWhile (\c -> true) "abc" == "abc"
+--  assert $ takeWhile (\c -> false) "abc" == ""
+--  assert $ takeWhile (\c -> c /= 'b') "aabbcc" == "aa"
+--
+--  log "indexOf'"
+--  assert $ indexOf' (Pattern "") 0 "" == Just 0
+--  assert $ indexOf' (Pattern "") (-1) "ab" == Nothing
+--  assert $ indexOf' (Pattern "") 0 "ab" == Just 0
+--  assert $ indexOf' (Pattern "") 1 "ab" == Just 1
+--  assert $ indexOf' (Pattern "") 2 "ab" == Just 2
+--  assert $ indexOf' (Pattern "") 3 "ab" == Nothing
+--  assert $ indexOf' (Pattern "bc") 0 "abcd" == Just 1
+--  assert $ indexOf' (Pattern "bc") 1 "abcd" == Just 1
+--  assert $ indexOf' (Pattern "bc") 2 "abcd" == Nothing
+--  assert $ indexOf' (Pattern "cb") 0 "abcd" == Nothing
+--
+--  log "lastIndexOf"
+--  assert $ lastIndexOf (Pattern "") "" == Just 0
+--  assert $ lastIndexOf (Pattern "") "abcd" == Just 4
+--  assert $ lastIndexOf (Pattern "bc") "abcd" == Just 1
+--  assert $ lastIndexOf (Pattern "cb") "abcd" == Nothing
+--
+--  log "lastIndexOf'"
+--  assert $ lastIndexOf' (Pattern "") 0 "" == Just 0
+--  assert $ lastIndexOf' (Pattern "") (-1) "ab" == Nothing
+--  assert $ lastIndexOf' (Pattern "") 0 "ab" == Just 0
+--  assert $ lastIndexOf' (Pattern "") 1 "ab" == Just 1
+--  assert $ lastIndexOf' (Pattern "") 2 "ab" == Just 2
+--  assert $ lastIndexOf' (Pattern "") 3 "ab" == Nothing
+--  assert $ lastIndexOf' (Pattern "bc") 0 "abcd" == Nothing
+--  assert $ lastIndexOf' (Pattern "bc") 1 "abcd" == Just 1
+--  assert $ lastIndexOf' (Pattern "bc") 2 "abcd" == Just 1
+--  assert $ lastIndexOf' (Pattern "cb") 0 "abcd" == Nothing
+--
+--  log "length"
+--  assert $ length "" == 0
+--  assert $ length "a" == 1
+--  assert $ length "ab" == 2
+--
+--  log "take"
+--  assert $ take 0 "ab" == ""
+--  assert $ take 1 "ab" == "a"
+--  assert $ take 2 "ab" == "ab"
+--  assert $ take 3 "ab" == "ab"
+--  assert $ take (-1) "ab" == ""
+--
+--  log "count"
+--  assert $ count (_ == 'a') "" == 0
+--  assert $ count (_ == 'a') "ab" == 1
+--  assert $ count (_ == 'a') "aaab" == 3
+--  assert $ count (_ == 'a') "abaa" == 1
+--
+--  log "splitAt"
+--  let testSplitAt i str res =
+--        assert $ case splitAt i str of
+--          Nothing ->
+--            isNothing res
+--          Just { before, after } ->
+--            maybe false (\r ->
+--              r.before == before && r.after == after) res
+--
+--  testSplitAt 1 "" Nothing
+--  testSplitAt 0 "a" $ Just {before: "", after: "a"}
+--  testSplitAt 1 "ab" $ Just {before: "a", after: "b"}
+--  testSplitAt 3 "aabcc" $ Just {before: "aab", after: "cc"}
+--  testSplitAt (-1) "abc" $ Nothing

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -101,17 +101,30 @@ testStringCodePoints = do
   log "lastIndexOf'"
   assert $ lastIndexOf' (Pattern "") 0 "" == Just 0
   assert $ lastIndexOf' (Pattern str) 0 str == Just 0
-  assert $ lastIndexOf' (Pattern str) 1 str == Nothing
+  assert $ lastIndexOf' (Pattern str) 1 str == Just 0
   assert $ lastIndexOf' (Pattern "a") 0 str == Just 0
-  assert $ lastIndexOf' (Pattern "a") 1 str == Nothing
-  assert $ lastIndexOf' (Pattern "z") 0 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 1 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 2 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 3 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 4 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 5 str == Just 6
+  assert $ lastIndexOf' (Pattern "a") 7 str == Just 0
+  assert $ lastIndexOf' (Pattern "z") 0 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 1 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 2 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 3 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 4 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 5 str == Nothing
   assert $ lastIndexOf' (Pattern "z") 6 str == Just 6
-  assert $ lastIndexOf' (Pattern "z") 7 str == Nothing
+  assert $ lastIndexOf' (Pattern "z") 7 str == Just 6
+  assert $ lastIndexOf' (Pattern "\xD800") 7 str == Just 3
+  assert $ lastIndexOf' (Pattern "\xD800") 6 str == Just 3
+  assert $ lastIndexOf' (Pattern "\xD800") 5 str == Just 3
+  assert $ lastIndexOf' (Pattern "\xD800") 4 str == Just 3
+  assert $ lastIndexOf' (Pattern "\xD800") 3 str == Just 3
+  assert $ lastIndexOf' (Pattern "\xD800") 2 str == Just 2
+  assert $ lastIndexOf' (Pattern "\xD800") 1 str == Nothing
+  assert $ lastIndexOf' (Pattern "\xD800") 0 str == Nothing
+  assert $ lastIndexOf' (Pattern "\x16A06") 7 str == Just 5
+  assert $ lastIndexOf' (Pattern "\x16A06") 6 str == Just 5
+  assert $ lastIndexOf' (Pattern "\x16A06") 5 str == Just 5
+  assert $ lastIndexOf' (Pattern "\x16A06") 4 str == Nothing
+  assert $ lastIndexOf' (Pattern "\x16A06") 3 str == Nothing
 
   log "length"
   assert $ length "" == 0

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -8,6 +8,7 @@ import Control.Monad.Eff.Console (CONSOLE)
 import Test.Assert (ASSERT)
 import Test.Data.Char (testChar)
 import Test.Data.String (testString)
+import Test.Data.String.CodePoints (testStringCodePoints)
 import Test.Data.String.Regex (testStringRegex)
 import Test.Data.String.Unsafe (testStringUnsafe)
 import Test.Data.String.CaseInsensitive (testCaseInsensitiveString)
@@ -16,6 +17,7 @@ main :: Eff (console :: CONSOLE, assert :: ASSERT) Unit
 main = do
   testChar
   testString
+  testStringCodePoints
   testStringUnsafe
   testStringRegex
   testCaseInsensitiveString


### PR DESCRIPTION
Functions in this module treat strings as if they were sequences of code points. I still want to pull more out of the FFI code and need to exercise all the FFI code paths by running on older browsers. But still, it should be ready for review. I'll squash after the review is done.