### PR TITLE
Ensure `genString` always generates at least one character

### DIFF
--- a/src/Data/String/Gen.purs
+++ b/src/Data/String/Gen.purs
@@ -10,7 +10,7 @@ import Data.String as S
 -- | Generates a string using the specified character generator.
 genString :: forall m. MonadRec m => MonadGen m => m Char -> m String
 genString genChar = sized \size -> do
-  newSize <- chooseInt 1 size
+  newSize <- chooseInt 1 (max 1 size)
   resize (const newSize) $ S.fromCharArray <$> unfoldable genChar
 
 -- | Generates a string using characters from the Unicode basic multilingual


### PR DESCRIPTION
I'm not exactly sure where to fix this, but here seems reasonable.

QC and SC behave differently when given `chooseInt 1 0` in that SC will always return 1 but QC will return either, so maybe this could be fixed in QC instead. I don't know what Jack does, so just making the change here at least ensures all will behave consistently.