### PR TITLE
Fix typo: 'plain' -> 'plane'

### DIFF
--- a/src/Data/Char/Gen.purs
+++ b/src/Data/Char/Gen.purs
@@ -6,7 +6,7 @@ import Control.Monad.Gen (class MonadGen, chooseInt, oneOf)
 import Data.Char as C
 import Data.NonEmpty ((:|))
 
--- | Generates a character of the Unicode basic multilingual plain.
+-- | Generates a character of the Unicode basic multilingual plane.
 genUnicodeChar :: forall m. MonadGen m => m Char
 genUnicodeChar = C.fromCharCode <$> chooseInt 0 65536
 


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane

Just a small typo I noticed in the doc comments.