### PR TITLE
Quote strings in Show instances

### DIFF
--- a/src/Data/String.purs
+++ b/src/Data/String.purs
@@ -50,7 +50,7 @@ derive instance ordPattern :: Ord Pattern
 derive instance newtypePattern :: Newtype Pattern _
 
 instance showPattern :: Show Pattern where
-  show (Pattern s) = "(Pattern " <> s <> ")"
+  show (Pattern s) = "(Pattern " <> show s <> ")"
 
 -- | A newtype used in cases to specify a replacement for a pattern.
 newtype Replacement = Replacement String
@@ -60,7 +60,7 @@ derive instance ordReplacement :: Ord Replacement
 derive instance newtypeReplacement :: Newtype Replacement _
 
 instance showReplacement :: Show Replacement where
-  show (Replacement s) = "(Replacement " <> s <> ")"
+  show (Replacement s) = "(Replacement " <> show s <> ")"
 
 -- | Returns the character at the given index, if the index is within bounds.
 charAt :: Int -> String -> Maybe Char

--- a/src/Data/String/CaseInsensitiveString.purs
+++ b/src/Data/String/CaseInsensitiveString.purs
@@ -17,6 +17,6 @@ instance ordCaseInsensitiveString :: Ord CaseInsensitiveString where
     compare (toLower s1) (toLower s2)
 
 instance showCaseInsensitiveString :: Show CaseInsensitiveString where
-  show (CaseInsensitiveString s) = "(CaseInsensitiveString " <> s <> ")"
+  show (CaseInsensitiveString s) = "(CaseInsensitiveString " <> show s <> ")"
 
 derive instance newtypeCaseInsensitiveString :: Newtype CaseInsensitiveString _


### PR DESCRIPTION
Usually in Haskell, strings are shown with quotes, so I presume PureScript follows the same convention.