### PR TITLE
Reuse the array returned by match

### DIFF
--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -49,11 +49,10 @@ exports._match = function (just) {
         if (m == null) {
           return nothing;
         } else {
-          var list = [];
           for (var i = 0; i < m.length; i++) {
-            list.push(m[i] == null ? nothing : just(m[i]));
+            m[i] = m[i] == null ? nothing : just(m[i]);
           }
-          return just(list);
+          return just(m);
         }
       };
     };


### PR DESCRIPTION
Instead of basically making a copy and letting the original go out of scope immediately after.

This makes a surprisingly large performance difference in Chrome, not so much in Firefox.