### PR TITLE
added function codePointFromChar

### DIFF
--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -8,6 +8,7 @@ module Data.String.CodePoints
   , codePointAt
   , codePointFromInt
   , codePointToInt
+  , codePointFromChar
   , count
   , drop
   , dropWhile
@@ -28,6 +29,7 @@ module Data.String.CodePoints
 import Prelude
 
 import Data.Array as Array
+import Data.Char (toCharCode)
 import Data.Char as Char
 import Data.Maybe (Maybe(Just, Nothing))
 import Data.String as String
@@ -59,6 +61,16 @@ codePointFromInt n = Nothing
 
 codePointToInt :: CodePoint -> Int
 codePointToInt (CodePoint n) = n
+
+-- | Creates a CodePoint from a given Char.
+-- |
+-- | ```purescript
+-- | codePointFromChar 'B'
+-- |    == CodePoint "B"
+-- | ```
+-- |  
+codePointFromChar :: Char -> CodePoint
+codePointFromChar = toCharCode >>> CodePoint
 
 unsurrogate :: Int -> Int -> CodePoint
 unsurrogate lead trail = CodePoint ((lead - 0xD800) * 0x400 + (trail - 0xDC00) + 0x10000)

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -66,7 +66,7 @@ codePointToInt (CodePoint n) = n
 -- |
 -- | ```purescript
 -- | codePointFromChar 'B'
--- |    == CodePoint "B"
+-- |    == CodePoint 0x42 -- represents 'B'
 -- | ```
 -- |  
 codePointFromChar :: Char -> CodePoint

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -65,8 +65,8 @@ codePointToInt (CodePoint n) = n
 -- | Creates a CodePoint from a given Char.
 -- |
 -- | ```purescript
--- | codePointFromChar 'B'
--- |    == CodePoint 0x42 -- represents 'B'
+-- | >>> codePointFromChar 'B'
+-- | CodePoint 0x42 -- represents 'B'
 -- | ```
 -- |  
 codePointFromChar :: Char -> CodePoint

--- a/test/Test/Data/String/CodePoints.purs
+++ b/test/Test/Data/String/CodePoints.purs
@@ -5,6 +5,7 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Console (CONSOLE, log)
 
+import Data.Char (fromCharCode)
 import Data.Maybe (Maybe(..), isNothing, maybe)
 import Data.String.CodePoints
 
@@ -25,6 +26,11 @@ testStringCodePoints = do
   assert $ codePointAt 5 str == (codePointFromInt 0x16A06)
   assert $ codePointAt 6 str == (codePointFromInt 0x7A)
   assert $ codePointAt 7 str == Nothing
+
+  log "codePointFromChar"
+  assert $ Just (codePointFromChar 'A') == (codePointFromInt 65)
+  assert $ Just (codePointFromChar $ fromCharCode 0) == codePointFromInt 0
+  assert $ Just (codePointFromChar $ fromCharCode 0xFFFF) == codePointFromInt 0xFFFF
 
   log "count"
   assert $ count (\_ -> true) "" == 0


### PR DESCRIPTION
while writing documentation for `Data.String.CodePoints` I realized that a function converting a char to a codepoint might be useful.
Correct me if I am wrong but the charcode should always be smaller than `0x10FFFF`