### PR TITLE
Fix out of bounds access in `unsafeCodePointAt0Fallback`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "clean": "rimraf output && rimraf .pulp-cache",
     "build": "eslint src && pulp build -- --censor-lib --strict",
-    "test": "pulp test",
+    "test": "pulp test && npm run test:run:without_codePointAt",
+    "test:run:without_codePointAt": "node -e \"delete String.prototype.codePointAt; require('./output/Test.Main/index.js').main();\"",
     "bench:build": "purs compile 'bench/**/*.purs' 'src/**/*.purs' 'bower_components/*/src/**/*.purs'",
     "bench:run": "node --expose-gc -e 'require(\"./output/Bench.Main/index.js\").main()'",
     "bench": "npm run bench:build && npm run bench:run"

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -415,8 +415,10 @@ unsafeCodePointAt0Fallback :: String -> CodePoint
 unsafeCodePointAt0Fallback s =
   let
     cu0 = fromEnum (Unsafe.charAt 0 s)
-    cu1 = fromEnum (Unsafe.charAt 1 s)
   in
-    if isLead cu0 && isTrail cu1
-       then unsurrogate cu0 cu1
-       else CodePoint cu0
+    if isLead cu0 && CU.length s > 1
+       then
+         let cu1 = fromEnum (Unsafe.charAt 1 s) in
+         if isTrail cu1 then unsurrogate cu0 cu1 else CodePoint cu0
+       else
+         CodePoint cu0


### PR DESCRIPTION
The precondition for `unsafeCodePointAt0` is that the string length in code units is at least 1. But the fallback version only worked for length > 2, because it always accessed index 1.

This was not caught by the test suite, because fallbacks are not used in node.js. I added a second test run to the test script that forces the use of fallbacks.