### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Data/String/CodeUnits.js
+++ b/src/Data/String/CodeUnits.js
@@ -53,7 +53,7 @@ exports._indexOf = function (just) {
   };
 };
 
-exports["_indexOf'"] = function (just) {
+exports._indexOfStartingAt = function (just) {
   return function (nothing) {
     return function (x) {
       return function (startAt) {
@@ -78,7 +78,7 @@ exports._lastIndexOf = function (just) {
   };
 };
 
-exports["_lastIndexOf'"] = function (just) {
+exports._lastIndexOfStartingAt = function (just) {
   return function (nothing) {
     return function (x) {
       return function (startAt) {

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -188,9 +188,9 @@ foreign import _indexOf
 -- | ```
 -- |
 indexOf' :: Pattern -> Int -> String -> Maybe Int
-indexOf' = _indexOf' Just Nothing
+indexOf' = _indexOfStartingAt Just Nothing
 
-foreign import _indexOf'
+foreign import _indexOfStartingAt
   :: (forall a. a -> Maybe a)
   -> (forall a. Maybe a)
   -> Pattern
@@ -228,9 +228,9 @@ foreign import _lastIndexOf
 -- | ```
 -- |
 lastIndexOf' :: Pattern -> Int -> String -> Maybe Int
-lastIndexOf' = _lastIndexOf' Just Nothing
+lastIndexOf' = _lastIndexOfStartingAt Just Nothing
 
-foreign import _lastIndexOf'
+foreign import _lastIndexOfStartingAt
   :: (forall a. a -> Maybe a)
   -> (forall a. Maybe a)
   -> Pattern

--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -1,10 +1,10 @@
 "use strict";
 
-exports["showRegex'"] = function (r) {
+exports.showRegexImpl = function (r) {
   return "" + r;
 };
 
-exports["regex'"] = function (left) {
+exports.regexImpl = function (left) {
   return function (right) {
     return function (s1) {
       return function (s2) {
@@ -22,7 +22,7 @@ exports.source = function (r) {
   return r.source;
 };
 
-exports["flags'"] = function (r) {
+exports.flagsImpl = function (r) {
   return {
     multiline: r.multiline,
     ignoreCase: r.ignoreCase,
@@ -67,7 +67,7 @@ exports.replace = function (r) {
   };
 };
 
-exports["replace'"] = function (r) {
+exports.replaceBy = function (r) {
   return function (f) {
     return function (s2) {
       return s2.replace(r, function (match) {

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -28,12 +28,12 @@ import Data.String.Regex.Flags (RegexFlags(..), RegexFlagsRec)
 -- | Wraps Javascript `RegExp` objects.
 foreign import data Regex :: Type
 
-foreign import showRegex' :: Regex -> String
+foreign import showRegexImpl :: Regex -> String
 
 instance showRegex :: Show Regex where
-  show = showRegex'
+  show = showRegexImpl
 
-foreign import regex'
+foreign import regexImpl
   :: (String -> Either String Regex)
   -> (Regex -> Either String Regex)
   -> String
@@ -43,17 +43,17 @@ foreign import regex'
 -- | Constructs a `Regex` from a pattern string and flags. Fails with
 -- | `Left error` if the pattern contains a syntax error.
 regex :: String -> RegexFlags -> Either String Regex
-regex s f = regex' Left Right s $ renderFlags f
+regex s f = regexImpl Left Right s $ renderFlags f
 
 -- | Returns the pattern string used to construct the given `Regex`.
 foreign import source :: Regex -> String
 
 -- | Returns the `RegexFlags` used to construct the given `Regex`.
 flags :: Regex -> RegexFlags
-flags = RegexFlags <<< flags'
+flags = RegexFlags <<< flagsImpl
 
 -- | Returns the `RegexFlags` inner record used to construct the given `Regex`.
-foreign import flags' :: Regex -> RegexFlagsRec
+foreign import flagsImpl :: Regex -> RegexFlagsRec
 
 -- | Returns the string representation of the given `RegexFlags`.
 renderFlags :: RegexFlags -> String
@@ -101,7 +101,10 @@ foreign import replace :: Regex -> String -> String -> String
 -- | Transforms occurences of the `Regex` using a function of the matched
 -- | substring and a list of submatch strings.
 -- | See the [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter).
-foreign import replace' :: Regex -> (String -> Array String -> String) -> String -> String
+replace' :: Regex -> (String -> Array String -> String) -> String -> String
+replace' = replaceBy
+
+foreign import replaceBy :: Regex -> (String -> Array String -> String) -> String -> String
 
 foreign import _search
   :: (forall r. r -> Maybe r)


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.