### PR TITLE
update replace' to reflect the existence of optional capturing groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.0-rc3"
+          purescript: "0.14.0-rc5"
 
       - uses: actions/setup-node@v1
         with:

--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -68,12 +68,21 @@ exports.replace = function (r) {
   };
 };
 
-exports.replaceBy = function (r) {
-  return function (f) {
-    return function (s2) {
-      return s2.replace(r, function (match) {
-        return f(match)(Array.prototype.splice.call(arguments, 1, arguments.length - 3));
-      });
+exports._replaceBy = function (just) {
+  return function (nothing) {
+    return function (r) {
+      return function (f) {
+        return function (s) {
+          return s.replace(r, function (match) {
+            var groups = [];
+            var group, i = 1;
+            while (typeof (group = arguments[i++]) !== "number") {
+              groups.push(group == null ? nothing : just(group));
+            }
+            return f(match)(groups);
+          });
+        };
+      };
     };
   };
 };

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -1,5 +1,5 @@
 -- | Wraps Javascript's `RegExp` object that enables matching strings with
--- | patternes defined by regular expressions.
+-- | patterns defined by regular expressions.
 -- | For details of the underlying implementation, see [RegExp Reference at MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).
 module Data.String.Regex
   ( Regex(..)
@@ -95,18 +95,25 @@ foreign import _match
 match :: Regex -> String -> Maybe (NonEmptyArray (Maybe String))
 match = _match Just Nothing
 
--- | Replaces occurences of the `Regex` with the first string. The replacement
+-- | Replaces occurrences of the `Regex` with the first string. The replacement
 -- | string can include special replacement patterns escaped with `"$"`.
 -- | See [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace).
 foreign import replace :: Regex -> String -> String -> String
 
--- | Transforms occurences of the `Regex` using a function of the matched
--- | substring and a list of submatch strings.
--- | See the [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter).
-replace' :: Regex -> (String -> Array String -> String) -> String -> String
-replace' = replaceBy
+foreign import _replaceBy
+  :: (forall r. r -> Maybe r)
+  -> (forall r. Maybe r)
+  -> Regex
+  -> (String -> Array (Maybe String) -> String)
+  -> String
+  -> String
 
-foreign import replaceBy :: Regex -> (String -> Array String -> String) -> String -> String
+-- | Transforms occurrences of the `Regex` using a function of the matched
+-- | substring and a list of captured substrings of type `Maybe String`,
+-- | where `Nothing` represents an unmatched optional capturing group.
+-- | See the [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter).
+replace' :: Regex -> (String -> Array (Maybe String) -> String) -> String -> String
+replace' = _replaceBy Just Nothing
 
 foreign import _search
   :: (forall r. r -> Maybe r)
@@ -120,5 +127,5 @@ foreign import _search
 search :: Regex -> String -> Maybe Int
 search = _search Just Nothing
 
--- | Split the string into an array of substrings along occurences of the `Regex`.
+-- | Split the string into an array of substrings along occurrences of the `Regex`.
 foreign import split :: Regex -> String -> Array String

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -10,7 +10,7 @@ import Data.String.Regex.Unsafe (unsafeRegex)
 import Effect (Effect)
 import Effect.Console (log)
 import Partial.Unsafe (unsafePartial)
-import Prelude (type (~>), Unit, discard, not, ($), (<<<), (<>), (==))
+import Prelude (type (~>), Unit, discard, not, show, ($), (<<<), (<>), (==))
 import Test.Assert (assert)
 
 testStringRegex :: Effect Unit
@@ -35,6 +35,10 @@ testStringRegex = do
 
   log "replace'"
   assert $ replace' (unsafeRegex "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<>" == "<>"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foo>" == "<[(Just \"foo\"),Nothing]>"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foobar>" == "<[(Just \"foo\"),(Just \"bar\")]>"
+  assert $ replace' (unsafeRegex "@(?<username>\\w+)" noFlags) (\s xs -> show xs) "@purescript" == "[(Just \"purescript\")]"
 
   log "search"
   assert $ search (unsafeRegex "b" noFlags) "abc" == Just 1


### PR DESCRIPTION
This pull request does for `replace'` what #32 did for `match`.

This pull request also fixes a few typos, renames a parameter (`s2` → `s`), and removes the mutation of `arguments` in `_replaceBy` (formerly `replaceBy`).

I would like to propose another breaking change to this function, so if you merge this pull request please do not release a new version of the package immediately. :)
