### PR TITLE
Use unsafeCrashWith for unsafeRegex (future fromEither not Partial) + Unix line endings

### DIFF
--- a/src/Data/String/Regex/Unsafe.purs
+++ b/src/Data/String/Regex/Unsafe.purs
@@ -2,7 +2,8 @@ module Data.String.Regex.Unsafe
   ( unsafeRegex
   ) where
 
-import Data.Either (fromRight)
+import Data.Maybe (fromJust)
+import Data.Either (hush)
 import Data.String.Regex (Regex, regex)
 import Data.String.Regex.Flags (RegexFlags)
 import Partial.Unsafe (unsafePartial)
@@ -10,4 +11,4 @@ import Partial.Unsafe (unsafePartial)
 -- | Constructs a `Regex` from a pattern string and flags. Fails with
 -- | an exception if the pattern contains a syntax error.
 unsafeRegex :: String -> RegexFlags -> Regex
-unsafeRegex s f = unsafePartial fromRight (regex s f)
+unsafeRegex s f = unsafePartial fromJust (hush (regex s f))

--- a/src/Data/String/Regex/Unsafe.purs
+++ b/src/Data/String/Regex/Unsafe.purs
@@ -2,13 +2,13 @@ module Data.String.Regex.Unsafe
   ( unsafeRegex
   ) where
 
-import Data.Maybe (fromJust)
-import Data.Either (hush)
+import Prelude (identity)
+import Data.Either (either)
 import Data.String.Regex (Regex, regex)
 import Data.String.Regex.Flags (RegexFlags)
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafeCrashWith)
 
 -- | Constructs a `Regex` from a pattern string and flags. Fails with
 -- | an exception if the pattern contains a syntax error.
 unsafeRegex :: String -> RegexFlags -> Regex
-unsafeRegex s f = unsafePartial fromJust (hush (regex s f))
+unsafeRegex s f = either (unsafeCrashWith identity) (regex s f)

--- a/src/Data/String/Regex/Unsafe.purs
+++ b/src/Data/String/Regex/Unsafe.purs
@@ -11,4 +11,4 @@ import Partial.Unsafe (unsafeCrashWith)
 -- | Constructs a `Regex` from a pattern string and flags. Fails with
 -- | an exception if the pattern contains a syntax error.
 unsafeRegex :: String -> RegexFlags -> Regex
-unsafeRegex s f = either (unsafeCrashWith identity) (regex s f)
+unsafeRegex s f = either unsafeCrashWith identity (regex s f)

--- a/src/Data/String/Regex/Unsafe.purs
+++ b/src/Data/String/Regex/Unsafe.purs
@@ -1,11 +1,10 @@
 module Data.String.Regex.Unsafe
-( unsafeRegex
-) where
+  ( unsafeRegex
+  ) where
 
 import Data.Either (fromRight)
 import Data.String.Regex (Regex, regex)
 import Data.String.Regex.Flags (RegexFlags)
-
 import Partial.Unsafe (unsafePartial)
 
 -- | Constructs a `Regex` from a pattern string and flags. Fails with


### PR DESCRIPTION
The future version of `Data.Either.fromRight` is no longer `Partial`, so `fromJust ∘ hush` is a way around this as `fromJust` is still Partial but not ideal. ~~Alternatively, `Data.Either` should have like `Data.Either.Partial.fromRight` to restore previous behavior (closes [either #56](https://github.com/purescript/purescript-either/issues/56))~~.

It was decided that it would be better to `unsafeCrashWith` on the `Left`-hand side of Regex instantiation.

Seemed really out of place to have one file with DOS line endings. Also, purty was run on this.