### PR TITLE
Use coerce instead of unsafeCoerce where appropriate

### DIFF
--- a/src/Data/String/NonEmpty/CodePoints.purs
+++ b/src/Data/String/NonEmpty/CodePoints.purs
@@ -33,19 +33,19 @@ import Data.Semigroup.Foldable (class Foldable1)
 import Data.Semigroup.Foldable as F1
 import Data.String.CodePoints (CodePoint)
 import Data.String.CodePoints as CP
-import Data.String.NonEmpty.Internal (NonEmptyString, fromString)
+import Data.String.NonEmpty.Internal (NonEmptyString(..), fromString)
 import Data.String.Pattern (Pattern)
 import Partial.Unsafe (unsafePartial)
 import Unsafe.Coerce (unsafeCoerce)
 
 toNonEmptyString :: String -> NonEmptyString
-toNonEmptyString = unsafeCoerce
+toNonEmptyString = NonEmptyString
 
 fromNonEmptyString :: NonEmptyString -> String
-fromNonEmptyString = unsafeCoerce
+fromNonEmptyString (NonEmptyString s) = s
 
 liftS :: forall r. (String -> r) -> NonEmptyString -> r
-liftS = unsafeCoerce
+liftS f (NonEmptyString s) = f s
 
 fromCodePointArray :: Array CodePoint -> Maybe NonEmptyString
 fromCodePointArray = case _ of

--- a/src/Data/String/NonEmpty/CodePoints.purs
+++ b/src/Data/String/NonEmpty/CodePoints.purs
@@ -37,12 +37,15 @@ import Data.String.NonEmpty.Internal (NonEmptyString(..), fromString)
 import Data.String.Pattern (Pattern)
 import Partial.Unsafe (unsafePartial)
 
+-- For internal use only. Do not export.
 toNonEmptyString :: String -> NonEmptyString
 toNonEmptyString = NonEmptyString
 
+-- For internal use only. Do not export.
 fromNonEmptyString :: NonEmptyString -> String
 fromNonEmptyString (NonEmptyString s) = s
 
+-- For internal use only. Do not export.
 liftS :: forall r. (String -> r) -> NonEmptyString -> r
 liftS f (NonEmptyString s) = f s
 

--- a/src/Data/String/NonEmpty/CodePoints.purs
+++ b/src/Data/String/NonEmpty/CodePoints.purs
@@ -36,7 +36,6 @@ import Data.String.CodePoints as CP
 import Data.String.NonEmpty.Internal (NonEmptyString(..), fromString)
 import Data.String.Pattern (Pattern)
 import Partial.Unsafe (unsafePartial)
-import Unsafe.Coerce (unsafeCoerce)
 
 toNonEmptyString :: String -> NonEmptyString
 toNonEmptyString = NonEmptyString

--- a/src/Data/String/NonEmpty/CodeUnits.purs
+++ b/src/Data/String/NonEmpty/CodeUnits.purs
@@ -33,20 +33,20 @@ import Data.Maybe (Maybe(..), fromJust)
 import Data.Semigroup.Foldable (class Foldable1)
 import Data.Semigroup.Foldable as F1
 import Data.String.CodeUnits as CU
-import Data.String.NonEmpty.Internal (NonEmptyString, fromString)
+import Data.String.NonEmpty.Internal (NonEmptyString(..), fromString)
 import Data.String.Pattern (Pattern)
 import Data.String.Unsafe as U
 import Partial.Unsafe (unsafePartial)
 import Unsafe.Coerce (unsafeCoerce)
 
 toNonEmptyString :: String -> NonEmptyString
-toNonEmptyString = unsafeCoerce
+toNonEmptyString = NonEmptyString
 
 fromNonEmptyString :: NonEmptyString -> String
-fromNonEmptyString = unsafeCoerce
+fromNonEmptyString (NonEmptyString s) = s
 
 liftS :: forall r. (String -> r) -> NonEmptyString -> r
-liftS = unsafeCoerce
+liftS f (NonEmptyString s) = f s
 
 -- | Creates a `NonEmptyString` from a character array `String`, returning
 -- | `Nothing` if the input is empty.

--- a/src/Data/String/NonEmpty/CodeUnits.purs
+++ b/src/Data/String/NonEmpty/CodeUnits.purs
@@ -39,12 +39,15 @@ import Data.String.Unsafe as U
 import Partial.Unsafe (unsafePartial)
 import Unsafe.Coerce (unsafeCoerce)
 
+-- For internal use only. Do not export.
 toNonEmptyString :: String -> NonEmptyString
 toNonEmptyString = NonEmptyString
 
+-- For internal use only. Do not export.
 fromNonEmptyString :: NonEmptyString -> String
 fromNonEmptyString (NonEmptyString s) = s
 
+-- For internal use only. Do not export.
 liftS :: forall r. (String -> r) -> NonEmptyString -> r
 liftS f (NonEmptyString s) = f s
 

--- a/src/Data/String/NonEmpty/Internal.purs
+++ b/src/Data/String/NonEmpty/Internal.purs
@@ -20,7 +20,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 -- | A string that is known not to be empty.
 -- |
--- | You can use this constructor to create a NonEmptyString that isn't
+-- | You can use this constructor to create a `NonEmptyString` that isn't
 -- | non-empty, breaking the guarantee behind this newtype. It is
 -- | provided as an escape hatch mainly for the `Data.NonEmpty.CodeUnits`
 -- | and `Data.NonEmpty.CodePoints` modules. Use this at your own risk

--- a/src/Data/String/NonEmpty/Internal.purs
+++ b/src/Data/String/NonEmpty/Internal.purs
@@ -19,13 +19,13 @@ import Prim.TypeError as TE
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | A string that is known not to be empty.
-newtype NonEmptyString =
-  -- | You can use this constructor to create a NonEmptyString that isn't
-  -- | non-empty, breaking the guarantee behind this newtype. It is
-  -- | provided as an escape hatch mainly for the `Data.NonEmpty.CodeUnits`
-  -- | and `Data.NonEmpty.CodePoints` modules. Use this at your own risk
-  -- | when you know what you are doing.
-  NonEmptyString String
+-- |
+-- | You can use this constructor to create a NonEmptyString that isn't
+-- | non-empty, breaking the guarantee behind this newtype. It is
+-- | provided as an escape hatch mainly for the `Data.NonEmpty.CodeUnits`
+-- | and `Data.NonEmpty.CodePoints` modules. Use this at your own risk
+-- | when you know what you are doing.
+newtype NonEmptyString = NonEmptyString String
 
 derive newtype instance eqNonEmptyString ∷ Eq NonEmptyString
 derive newtype instance ordNonEmptyString ∷ Ord NonEmptyString

--- a/src/Data/String/NonEmpty/Internal.purs
+++ b/src/Data/String/NonEmpty/Internal.purs
@@ -1,3 +1,9 @@
+-- | While most of the code in this module is safe, this module does
+-- | export a few partial functions and the `NonEmptyString` constructor.
+-- | While the partial functions are obvious from the `Partial` constraint in
+-- | their type signature, the `NonEmptyString` constructor can be overlooked
+-- | when searching for issues in one's code. See the constructor's
+-- | documentation for more information.
 module Data.String.NonEmpty.Internal where
 
 import Prelude
@@ -13,7 +19,15 @@ import Prim.TypeError as TE
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | A string that is known not to be empty.
-newtype NonEmptyString = NonEmptyString String
+newtype NonEmptyString =
+  -- | You can use this constructor to create a NonEmptyString that isn't
+  -- | non-empty, breaking the guarantee behind this newtype. It is
+  -- | provided as an escape hatch mainly for the `Data.NonEmpty.CodeUnits`
+  -- | and `Data.NonEmpty.CodePoints` modules. Usage of this constructor
+  -- | in your own code provides the same safety guarantees of
+  -- | `unsafeCoerce`, that is, none at all. Use this at your own risk
+  -- | when you know what you are doing.
+  NonEmptyString String
 
 derive newtype instance eqNonEmptyString ∷ Eq NonEmptyString
 derive newtype instance ordNonEmptyString ∷ Ord NonEmptyString

--- a/src/Data/String/NonEmpty/Internal.purs
+++ b/src/Data/String/NonEmpty/Internal.purs
@@ -23,9 +23,7 @@ newtype NonEmptyString =
   -- | You can use this constructor to create a NonEmptyString that isn't
   -- | non-empty, breaking the guarantee behind this newtype. It is
   -- | provided as an escape hatch mainly for the `Data.NonEmpty.CodeUnits`
-  -- | and `Data.NonEmpty.CodePoints` modules. Usage of this constructor
-  -- | in your own code provides the same safety guarantees of
-  -- | `unsafeCoerce`, that is, none at all. Use this at your own risk
+  -- | and `Data.NonEmpty.CodePoints` modules. Use this at your own risk
   -- | when you know what you are doing.
   NonEmptyString String
 


### PR DESCRIPTION
Implements the suggestions made [here](https://github.com/purescript/purescript-strings/pull/129#issuecomment-716062932): replace `unsafeCoerce` with `coerce` where appropriate.