### PR TITLE
add dotAll regexp flag

### DIFF
--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -27,6 +27,7 @@ exports.flagsImpl = function (r) {
     multiline: r.multiline,
     ignoreCase: r.ignoreCase,
     global: r.global,
+    dotAll: r.dotAll,
     sticky: !!r.sticky,
     unicode: !!r.unicode
   };

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -61,6 +61,7 @@ renderFlags (RegexFlags f) =
   (if f.global then "g" else "") <>
   (if f.ignoreCase then "i" else "") <>
   (if f.multiline then "m" else "") <>
+  (if f.dotAll then "s" else "") <>
   (if f.sticky then "y" else "") <>
   (if f.unicode then "u" else "")
 
@@ -70,6 +71,7 @@ parseFlags s = RegexFlags
   { global: contains (Pattern "g") s
   , ignoreCase: contains (Pattern "i") s
   , multiline: contains (Pattern "m") s
+  , dotAll: contains (Pattern "s") s
   , sticky: contains (Pattern "y") s
   , unicode: contains (Pattern "u") s
   }

--- a/src/Data/String/Regex/Flags.purs
+++ b/src/Data/String/Regex/Flags.purs
@@ -9,6 +9,7 @@ type RegexFlagsRec =
   { global :: Boolean
   , ignoreCase :: Boolean
   , multiline :: Boolean
+  , dotAll :: Boolean
   , sticky :: Boolean
   , unicode :: Boolean
   }
@@ -22,6 +23,7 @@ noFlags = RegexFlags
   { global: false
   , ignoreCase: false
   , multiline: false
+  , dotAll : false
   , sticky: false
   , unicode: false
   }
@@ -32,6 +34,7 @@ global = RegexFlags
   { global: true
   , ignoreCase: false
   , multiline: false
+  , dotAll : false
   , sticky: false
   , unicode: false
   }
@@ -42,6 +45,7 @@ ignoreCase = RegexFlags
   { global: false
   , ignoreCase: true
   , multiline: false
+  , dotAll : false
   , sticky: false
   , unicode: false
   }
@@ -52,6 +56,7 @@ multiline = RegexFlags
   { global: false
   , ignoreCase: false
   , multiline: true
+  , dotAll : false
   , sticky: false
   , unicode: false
   }
@@ -62,6 +67,7 @@ sticky = RegexFlags
   { global: false
   , ignoreCase: false
   , multiline: false
+  , dotAll : false
   , sticky: true
   , unicode: false
   }
@@ -72,8 +78,20 @@ unicode = RegexFlags
   { global: false
   , ignoreCase: false
   , multiline: false
+  , dotAll : false
   , sticky: false
   , unicode: true
+  }
+
+-- | Only dotAll flag set to true
+dotAll :: RegexFlags
+dotAll = RegexFlags
+  { global: false
+  , ignoreCase: false
+  , multiline: false
+  , dotAll : true
+  , sticky: false
+  , unicode: false
   }
 
 instance semigroupRegexFlags :: Semigroup RegexFlags where
@@ -81,6 +99,7 @@ instance semigroupRegexFlags :: Semigroup RegexFlags where
     { global: x.global || y.global
     , ignoreCase: x.ignoreCase || y.ignoreCase
     , multiline: x.multiline || y.multiline
+    , dotAll: x.dotAll || y.dotAll
     , sticky: x.sticky || y.sticky
     , unicode: x.unicode || y.unicode
     }
@@ -93,6 +112,7 @@ instance eqRegexFlags :: Eq RegexFlags where
     = x.global == y.global
     && x.ignoreCase == y.ignoreCase
     && x.multiline == y.multiline
+    && x.dotAll == y.dotAll
     && x.sticky == y.sticky
     && x.unicode == y.unicode
 
@@ -104,6 +124,7 @@ instance showRegexFlags :: Show RegexFlags where
         <> (guard flags.global $> "global")
         <> (guard flags.ignoreCase $> "ignoreCase")
         <> (guard flags.multiline $> "multiline")
+        <> (guard flags.dotAll $> "dotAll")
         <> (guard flags.sticky $> "sticky")
         <> (guard flags.unicode $> "unicode")
     in

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -5,7 +5,7 @@ import Data.String.Regex
 import Data.Array.NonEmpty (NonEmptyArray, fromArray)
 import Data.Either (isLeft)
 import Data.Maybe (Maybe(..), fromJust)
-import Data.String.Regex.Flags (global, ignoreCase, noFlags)
+import Data.String.Regex.Flags (dotAll, global, ignoreCase, noFlags)
 import Data.String.Regex.Unsafe (unsafeRegex)
 import Effect (Effect)
 import Effect.Console (log)
@@ -24,6 +24,7 @@ testStringRegex = do
   assert $ "quxbarfoobaz" == replace (unsafeRegex "foo" noFlags) "qux" "foobarfoobaz"
   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" global) "qux" "foobarfoobaz"
   assert $ "quxbarquxbaz" == replace (unsafeRegex "foo" (global <> ignoreCase)) "qux" "foobarFOObaz"
+  assert $ "quxbarquxbaz" == replace (unsafeRegex ".foo" dotAll) "qux" "\nfoobarfoobaz"
 
   log "match"
   assert $ match (unsafeRegex "^abc$" noFlags) "abc" == Just (nea [Just "abc"])


### PR DESCRIPTION
This flag is useful especially when it's used with replace function. Let's say we have a big string that contains html and we want to extract the title from it. If we have dotAll regexp flag, we can write the code like this:

`
replace (unsafeRegex "^.*<title>([^<]+)</title>.*$" dotAll) "$1" bigString
`
It's quite quick and simple. With this, we can remove unneeded parts over multiple lines. This flag is supported by ES2018 and currently, node.js and browsers other than Internet Explorer and Firefox for Android cover that.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll