### PR TITLE
simplify type of replace'

### DIFF
--- a/src/Data/String/Regex.js
+++ b/src/Data/String/Regex.js
@@ -73,13 +73,13 @@ exports._replaceBy = function (just) {
     return function (r) {
       return function (f) {
         return function (s) {
-          return s.replace(r, function (match) {
+          return s.replace(r, function () {
             var groups = [];
             var group, i = 1;
             while (typeof (group = arguments[i++]) !== "number") {
               groups.push(group == null ? nothing : just(group));
             }
-            return f(match)(groups);
+            return f(groups);
           });
         };
       };

--- a/src/Data/String/Regex.purs
+++ b/src/Data/String/Regex.purs
@@ -104,15 +104,15 @@ foreign import _replaceBy
   :: (forall r. r -> Maybe r)
   -> (forall r. Maybe r)
   -> Regex
-  -> (String -> Array (Maybe String) -> String)
+  -> (Array (Maybe String) -> String)
   -> String
   -> String
 
--- | Transforms occurrences of the `Regex` using a function of the matched
--- | substring and a list of captured substrings of type `Maybe String`,
--- | where `Nothing` represents an unmatched optional capturing group.
+-- | Transforms occurrences of the `Regex` using a function of
+-- | a list of captured substrings of type `Maybe String`, where
+-- | `Nothing` represents an unmatched optional capturing group.
 -- | See the [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_function_as_a_parameter).
-replace' :: Regex -> (String -> Array (Maybe String) -> String) -> String -> String
+replace' :: Regex -> (Array (Maybe String) -> String) -> String -> String
 replace' = _replaceBy Just Nothing
 
 foreign import _search

--- a/test/Test/Data/String/Regex.purs
+++ b/test/Test/Data/String/Regex.purs
@@ -34,11 +34,11 @@ testStringRegex = do
   assert $ replace (unsafeRegex "-" noFlags) "!" "a-b-c" == "a!b-c"
 
   log "replace'"
-  assert $ replace' (unsafeRegex "-" noFlags) (\s xs -> "!") "a-b-c" == "a!b-c"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<>" == "<>"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foo>" == "<[(Just \"foo\"),Nothing]>"
-  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) (\s xs -> show xs) "<foobar>" == "<[(Just \"foo\"),(Just \"bar\")]>"
-  assert $ replace' (unsafeRegex "@(?<username>\\w+)" noFlags) (\s xs -> show xs) "@purescript" == "[(Just \"purescript\")]"
+  assert $ replace' (unsafeRegex "-" noFlags) (\xs -> "!") "a-b-c" == "a!b-c"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) show "<>" == "<>"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) show "<foo>" == "<[(Just \"foo\"),Nothing]>"
+  assert $ replace' (unsafeRegex "(foo)(bar)?" noFlags) show "<foobar>" == "<[(Just \"foo\"),(Just \"bar\")]>"
+  assert $ replace' (unsafeRegex "@(?<username>\\w+)" noFlags) show "@purescript" == "[(Just \"purescript\")]"
 
   log "search"
   assert $ search (unsafeRegex "b" noFlags) "abc" == Just 1


### PR DESCRIPTION
Commit message:

> The `match` argument provided by [`String#replace`][1] (when given a function) is often irrelevant. If one *does* require access to the matched substring as a whole, one can parenthesize the whole pattern to capture it.

This is a breaking change, but I believe it would make `replace'` slightly more user-friendly.

This proposal was conceived while considering sanctuary-js/sanctuary#685 (as was #126).


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
