### PR TITLE
[WIP] relax Data.String.CodeUnits.slice + related changes as per #143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 - Migrate FFI to ES modules (#158 by @kl0tl and @JordanMartinez)
 - Replaced polymorphic proxies with monomorphic `Proxy` (#158 by @JordanMartinez)
+- In `slice`, drop bounds checking and `Maybe` return type (#145 by Quelklef)
 
 New features:
 

--- a/src/Data/String/CodeUnits.js
+++ b/src/Data/String/CodeUnits.js
@@ -103,7 +103,7 @@ exports.drop = function (n) {
   };
 };
 
-exports._slice = function (b) {
+exports.slice = function (b) {
   return function (e) {
     return function (s) {
       return s.slice(b,e);

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -298,30 +298,17 @@ dropWhile p s = drop (countPrefix p s) s
 
 -- | Returns the substring at indices `[begin, end)`.
 -- | If either index is negative, it is normalised to `length s - index`,
--- | where `s` is the input string. `Nothing` is returned if either
+-- | where `s` is the input string. `""` is returned if either
 -- | index is out of bounds or if `begin > end` after normalisation.
 -- |
 -- | ```purescript
--- | slice 0 0   "purescript" == Just ""
--- | slice 0 1   "purescript" == Just "p"
--- | slice 3 6   "purescript" == Just "esc"
--- | slice (-4) (-1) "purescript" == Just "rip"
--- | slice (-4) 3  "purescript" == Nothing
+-- | slice 0 0   "purescript" == ""
+-- | slice 0 1   "purescript" == "p"
+-- | slice 3 6   "purescript" == "esc"
+-- | slice (-4) (-1) "purescript" == "rip"
+-- | slice (-4) 3  "purescript" == ""
 -- | ```
-slice :: Int -> Int -> String -> Maybe String
-slice b e s = if b' < 0 || b' >= l ||
-                 e' < 0 || e' >  l ||
-                 b' > e'
-              then Nothing
-              else Just (_slice b e s)
-  where
-    l = length s
-    norm x | x < 0 = l + x
-           | otherwise = x
-    b' = norm b
-    e' = norm e
-
-foreign import _slice :: Int -> Int -> String -> String
+foreign import slice :: Int -> Int -> String -> String
 
 -- | Splits a string into two substrings, where `before` contains the
 -- | characters up to (but not including) the given index, and `after` contains

--- a/test/Test/Data/String/CodeUnits.purs
+++ b/test/Test/Data/String/CodeUnits.purs
@@ -472,41 +472,45 @@ testStringCodeUnits = do
   log "slice"
   assertEqual
     { actual: SCU.slice 0 0   "purescript"
-    , expected: Just ""
+    , expected: ""
     }
   assertEqual
     { actual: SCU.slice 0 1   "purescript"
-    , expected: Just "p"
+    , expected: "p"
     }
   assertEqual
     { actual: SCU.slice 3 6   "purescript"
-    , expected: Just "esc"
+    , expected: "esc"
     }
   assertEqual
     { actual: SCU.slice 3 10  "purescript"
-    , expected: Just "escript"
+    , expected: "escript"
+    }
+  assertEqual
+    { actual: SCU.slice 10 10 "purescript"
+    , expected: ""
     }
   assertEqual
     { actual: SCU.slice (-4) (-1) "purescript"
-    , expected: Just "rip"
+    , expected: "rip"
     }
   assertEqual
     { actual: SCU.slice (-4) 3  "purescript"
-    , expected: Nothing -- b' > e'
+    , expected: ""
     }
   assertEqual
     { actual: SCU.slice 1000 3  "purescript"
-    , expected: Nothing -- b' > e' (subsumes b > l)
+    , expected: ""
     }
   assertEqual
     { actual: SCU.slice 2 (-15) "purescript"
-    , expected: Nothing -- e' < 0
+    , expected: ""
     }
   assertEqual
     { actual: SCU.slice (-15) 9 "purescript"
-    , expected: Nothing -- b' < 0
+    , expected: "purescrip"
     }
   assertEqual
     { actual: SCU.slice 3 1000 "purescript"
-    , expected: Nothing -- e > l
+    , expected: "escript"
     }


### PR DESCRIPTION
**Description of the change**

This PR closes https://github.com/purescript/purescript-strings/issues/143.

That issue originally was about changing the bounds checking of `Data.String.CodeUntis.slice`. It has since been decided that the appropriate fix is to remove bounds checking altogether and to change the type from `Int -> Int -> Maybe String` to `Int -> Int -> String`.

Additionally, there is discussion in that ticket about improving similar string-and-index operations to be more consistent with the API. Hence the WIP-ness of this PR, so that those additional changes can be added as they are pointed out.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
