### PR TITLE
Add startsWith and endsWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added `startsWith` and `endsWith` (#147)
 
 Bugfixes:
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -34,7 +34,7 @@ import Data.Array as Array
 import Data.Enum (class BoundedEnum, class Enum, Cardinality(..), defaultPred, defaultSucc, fromEnum, toEnum, toEnumWithDefaults)
 import Data.Int (hexadecimal, toStringAs)
 import Data.Maybe (Maybe(..))
-import Data.String.CodeUnits (contains, stripPrefix, stripSuffix) as Exports
+import Data.String.CodeUnits (contains, stripPrefix, stripSuffix, startsWith, endsWith) as Exports
 import Data.String.CodeUnits as CU
 import Data.String.Common (toUpper)
 import Data.String.Pattern (Pattern)

--- a/src/Data/String/CodeUnits.js
+++ b/src/Data/String/CodeUnits.js
@@ -116,15 +116,3 @@ exports.splitAt = function (i) {
     return { before: s.substring(0, i), after: s.substring(i) };
   };
 };
-
-exports.startsWith = function (pattern) {
-  return function (s) {
-    return s.startsWith(pattern);
-  };
-};
-
-exports.endsWith = function (pattern) {
-  return function (s) {
-    return s.endsWith(pattern);
-  };
-};

--- a/src/Data/String/CodeUnits.js
+++ b/src/Data/String/CodeUnits.js
@@ -116,3 +116,15 @@ exports.splitAt = function (i) {
     return { before: s.substring(0, i), after: s.substring(i) };
   };
 };
+
+exports.startsWith = function (pattern) {
+  return function (s) {
+    return s.startsWith(pattern);
+  }
+}
+
+exports.endsWith = function (pattern) {
+  return function (s) {
+    return s.endsWith(pattern);
+  }
+}

--- a/src/Data/String/CodeUnits.js
+++ b/src/Data/String/CodeUnits.js
@@ -120,11 +120,11 @@ exports.splitAt = function (i) {
 exports.startsWith = function (pattern) {
   return function (s) {
     return s.startsWith(pattern);
-  }
-}
+  };
+};
 
 exports.endsWith = function (pattern) {
   return function (s) {
     return s.endsWith(pattern);
-  }
-}
+  };
+};

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -33,9 +33,10 @@ import Data.String.Pattern (Pattern(..))
 import Data.String.Unsafe as U
 
 -------------------------------------------------------------------------------
--- `stripPrefix`, `stripSuffix`, and `contains` are CodeUnit/CodePoint agnostic
--- as they are based on patterns rather than lengths/indices, but they need to
--- be defined in here to avoid a circular module dependency
+-- `stripPrefix`, `stripSuffix`, `startsWith`, `endsWith`, and `contains` are
+-- CodeUnit/CodePoint agnostic as they are based on patterns rather than
+-- lengths/indices, but they need to be defined in here to avoid a circular
+-- module dependency
 -------------------------------------------------------------------------------
 
 -- | If the string starts with the given prefix, return the portion of the
@@ -62,6 +63,30 @@ stripSuffix :: Pattern -> String -> Maybe String
 stripSuffix (Pattern suffix) str =
   let { before, after } = splitAt (length str - length suffix) str in
   if after == suffix then Just before else Nothing
+
+-- | Checks whether the given string starts with the pattern.
+-- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripPrefix`.
+-- |
+-- | ```purescript
+-- | startsWith (Pattern "foo") "foobar" == true
+-- | startsWith (Pattern "bar") "foobar" == false
+-- | ```
+startsWith :: Pattern -> String -> Boolean
+startsWith pat = isJust <<< stripPrefix pat
+
+-- | Checks whether the given string ends with the pattern.
+-- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripSuffix`.
+-- |
+-- | ```purescript
+-- | endsWith (Pattern "bar") "foobar" == true
+-- | endsWith (Pattern "foo") "foobar" == false
+-- | ```
+endsWith :: Pattern -> String -> Boolean
+endsWith pat = isJust <<< stripSuffix pat
 
 -- | Checks whether the pattern appears in the given string.
 -- |
@@ -345,27 +370,3 @@ foreign import _slice :: Int -> Int -> String -> String
 -- | splitAt i s == {before: take i s, after: drop i s}
 -- | ```
 foreign import splitAt :: Int -> String -> { before :: String, after :: String }
-
--- | Checks whether the given string starts with the pattern.
--- |
--- | **NOTE**: if you also want to get the string stripped of the pattern, see
--- | `stripPrefix`.
--- |
--- | ```purescript
--- | startsWith (Pattern "foo") "foobar" == true
--- | startsWith (Pattern "bar") "foobar" == false
--- | ```
-startsWith :: Pattern -> String -> Boolean
-startsWith pat = isJust <<< stripPrefix pat
-
--- | Checks whether the given string ends with the pattern.
--- |
--- | **NOTE**: if you also want to get the string stripped of the pattern, see
--- | `stripSuffix`.
--- |
--- | ```purescript
--- | endsWith (Pattern "bar") "foobar" == true
--- | endsWith (Pattern "foo") "foobar" == false
--- | ```
-endsWith :: Pattern -> String -> Boolean
-endsWith pat = isJust <<< stripSuffix pat

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -22,6 +22,8 @@ module Data.String.CodeUnits
   , dropWhile
   , slice
   , splitAt
+  , startsWith
+  , endsWith
   ) where
 
 import Prelude
@@ -343,3 +345,19 @@ foreign import _slice :: Int -> Int -> String -> String
 -- | splitAt i s == {before: take i s, after: drop i s}
 -- | ```
 foreign import splitAt :: Int -> String -> { before :: String, after :: String }
+
+-- | Checks whether the given string starts with the pattern.
+-- |
+-- | ```purescript
+-- | startsWith (Pattern "foo") "foobar" == true
+-- | startsWith (Pattern "bar") "foobar" == false
+-- | ```
+foreign import startsWith :: Pattern -> String -> Boolean
+
+-- | Checks whether the given string ends with the pattern.
+-- |
+-- | ```purescript
+-- | endsWith (Pattern "bar") "foobar" == true
+-- | endsWith (Pattern "foo") "foobar" == false
+-- | ```
+foreign import endsWith :: Pattern -> String -> Boolean

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -348,6 +348,9 @@ foreign import splitAt :: Int -> String -> { before :: String, after :: String }
 
 -- | Checks whether the given string starts with the pattern.
 -- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripPrefix`.
+-- |
 -- | ```purescript
 -- | startsWith (Pattern "foo") "foobar" == true
 -- | startsWith (Pattern "bar") "foobar" == false
@@ -356,6 +359,9 @@ startsWith :: Pattern -> String -> Boolean
 startsWith pat = isJust <<< stripPrefix pat
 
 -- | Checks whether the given string ends with the pattern.
+-- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripSuffix`.
 -- |
 -- | ```purescript
 -- | endsWith (Pattern "bar") "foobar" == true

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -352,7 +352,8 @@ foreign import splitAt :: Int -> String -> { before :: String, after :: String }
 -- | startsWith (Pattern "foo") "foobar" == true
 -- | startsWith (Pattern "bar") "foobar" == false
 -- | ```
-foreign import startsWith :: Pattern -> String -> Boolean
+startsWith :: Pattern -> String -> Boolean
+startsWith pat = isJust <<< stripPrefix pat
 
 -- | Checks whether the given string ends with the pattern.
 -- |
@@ -360,4 +361,5 @@ foreign import startsWith :: Pattern -> String -> Boolean
 -- | endsWith (Pattern "bar") "foobar" == true
 -- | endsWith (Pattern "foo") "foobar" == false
 -- | ```
-foreign import endsWith :: Pattern -> String -> Boolean
+endsWith :: Pattern -> String -> Boolean
+endsWith pat = isJust <<< stripSuffix pat

--- a/src/Data/String/NonEmpty.purs
+++ b/src/Data/String/NonEmpty.purs
@@ -4,6 +4,6 @@ module Data.String.NonEmpty
   , module Data.String.NonEmpty.CodePoints
   ) where
 
-import Data.String.NonEmpty.Internal (NonEmptyString, class MakeNonEmpty, NonEmptyReplacement(..), appendString, contains, fromString, join1With, joinWith, joinWith1, localeCompare, nes, prependString, replace, replaceAll, stripPrefix, stripSuffix, toLower, toString, toUpper, trim, unsafeFromString)
+import Data.String.NonEmpty.Internal (NonEmptyString, class MakeNonEmpty, NonEmptyReplacement(..), appendString, contains, fromString, join1With, joinWith, joinWith1, localeCompare, nes, prependString, replace, replaceAll, stripPrefix, stripSuffix, startsWith, endsWith, toLower, toString, toUpper, trim, unsafeFromString)
 import Data.String.Pattern (Pattern(..))
 import Data.String.NonEmpty.CodePoints

--- a/src/Data/String/NonEmpty/Internal.purs
+++ b/src/Data/String/NonEmpty/Internal.purs
@@ -123,6 +123,31 @@ stripPrefix pat = fromString <=< liftS (String.stripPrefix pat)
 stripSuffix :: Pattern -> NonEmptyString -> Maybe NonEmptyString
 stripSuffix pat = fromString <=< liftS (String.stripSuffix pat)
 
+
+-- | Checks whether the given string starts with the pattern.
+-- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripPrefix`.
+-- |
+-- | ```purescript
+-- | startsWith (Pattern "foo") (NonEmptyString "foobar") == true
+-- | startsWith (Pattern "bar") (NonEmptyString "foobar") == false
+-- | ```
+startsWith :: Pattern -> NonEmptyString -> Boolean
+startsWith = liftS <<< String.startsWith
+
+-- | Checks whether the given string ends with the pattern.
+-- |
+-- | **NOTE**: if you also want to get the string stripped of the pattern, see
+-- | `stripSuffix`.
+-- |
+-- | ```purescript
+-- | endsWith (Pattern "bar") (NonEmptyString "foobar") == true
+-- | endsWith (Pattern "foo") (NonEmptyString "foobar") == false
+-- | ```
+endsWith :: Pattern -> NonEmptyString -> Boolean
+endsWith = liftS <<< String.endsWith
+
 -- | Checks whether the pattern appears in the given string.
 -- |
 -- | ```purescript

--- a/test/Test/Data/String/CodeUnits.purs
+++ b/test/Test/Data/String/CodeUnits.purs
@@ -64,6 +64,20 @@ testStringCodeUnits = do
     , expected: Just ""
     }
 
+  log "startsWith"
+  assert $ SCU.startsWith (Pattern "foo") "foobar"
+  assert $ SCU.startsWith (Pattern "foo") "foo"
+  assert $ SCU.startsWith (Pattern "") ""
+  assert $ SCU.startsWith (Pattern "") "foo"
+  assert $ not $ SCU.startsWith (Pattern "foo") ""
+
+  log "endsWith"
+  assert $ SCU.endsWith (Pattern "bar") "foobar"
+  assert $ SCU.endsWith (Pattern "bar") "bar"
+  assert $ SCU.endsWith (Pattern "") ""
+  assert $ SCU.endsWith (Pattern "") "bar"
+  assert $ not $ SCU.endsWith (Pattern "bar") ""
+
   log "charAt"
   assertEqual
     { actual: SCU.charAt 0 ""
@@ -510,17 +524,3 @@ testStringCodeUnits = do
     { actual: SCU.slice 3 1000 "purescript"
     , expected: Nothing -- e > l
     }
-
-  log "startsWith"
-  assert $ SCU.startsWith (Pattern "foo") "foobar"
-  assert $ SCU.startsWith (Pattern "foo") "foo"
-  assert $ SCU.startsWith (Pattern "") ""
-  assert $ SCU.startsWith (Pattern "") "foo"
-  assert $ not $ SCU.startsWith (Pattern "foo") ""
-
-  log "endsWith"
-  assert $ SCU.endsWith (Pattern "bar") "foobar"
-  assert $ SCU.endsWith (Pattern "bar") "bar"
-  assert $ SCU.endsWith (Pattern "") ""
-  assert $ SCU.endsWith (Pattern "") "bar"
-  assert $ not $ SCU.endsWith (Pattern "bar") ""

--- a/test/Test/Data/String/CodeUnits.purs
+++ b/test/Test/Data/String/CodeUnits.purs
@@ -510,3 +510,17 @@ testStringCodeUnits = do
     { actual: SCU.slice 3 1000 "purescript"
     , expected: Nothing -- e > l
     }
+
+  log "startsWith"
+  assert $ SCU.startsWith (Pattern "foo") "foobar"
+  assert $ SCU.startsWith (Pattern "foo") "foo"
+  assert $ SCU.startsWith (Pattern "") ""
+  assert $ SCU.startsWith (Pattern "") "foo"
+  assert $ not $ SCU.startsWith (Pattern "foo") ""
+
+  log "endsWith"
+  assert $ SCU.endsWith (Pattern "bar") "foobar"
+  assert $ SCU.endsWith (Pattern "bar") "bar"
+  assert $ SCU.endsWith (Pattern "") ""
+  assert $ SCU.endsWith (Pattern "") "bar"
+  assert $ not $ SCU.endsWith (Pattern "bar") ""

--- a/test/Test/Data/String/NonEmpty.purs
+++ b/test/Test/Data/String/NonEmpty.purs
@@ -144,6 +144,19 @@ testNonEmptyString = do
     , expected: Nothing
     }
 
+  log "startsWith"
+  assert $ NES.startsWith (Pattern "foo") (nes (Proxy :: Proxy "foobar"))
+  assert $ NES.startsWith (Pattern "foo") (nes (Proxy :: Proxy "foo"))
+  assert $ NES.startsWith (Pattern "") (nes (Proxy :: Proxy "foo"))
+  assert $ not $ NES.startsWith (Pattern "foo") (nes (Proxy :: Proxy "f"))
+
+  log "endsWith"
+  assert $ NES.endsWith (Pattern "bar") (nes (Proxy :: Proxy "foobar"))
+  assert $ NES.endsWith (Pattern "bar") (nes (Proxy :: Proxy "bar"))
+  assert $ NES.endsWith (Pattern "") (nes (Proxy :: Proxy "f"))
+  assert $ NES.endsWith (Pattern "") (nes (Proxy :: Proxy "bar"))
+  assert $ not $ NES.endsWith (Pattern "bar") (nes (Proxy :: Proxy "b"))
+
   log "toLower"
   assertEqual
     { actual: NES.toLower (nes (Proxy :: Proxy "bAtMaN"))


### PR DESCRIPTION
**Description of the change**

Add `startsWith` and `endsWith` functions to `Data.String.CodeUnits`.

Fixes #127.

I know that there's still a bit of disagreement over whether this should be done or not, but I just opened this PR because it didn't take a lot of time. If it's ultimately decided against, feel free to close this PR.

To do:
- [x] suggest `stripPrefix` and `stripSuffix`
- [x] don't use FFI functions, instead use `stripPrefix` and `stripSuffix`
- [x] add functions to `Data.String.NonEmpty`

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
