### PR TITLE
Use backticks around PS code in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Surround code with backticks in documentation (#148)
 
 ## [v5.0.0](https://github.com/purescript/purescript-strings/releases/tag/v5.0.0) - 2021-02-26
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -42,7 +42,7 @@ import Data.String.Unsafe as Unsafe
 import Data.Tuple (Tuple(..))
 import Data.Unfoldable (unfoldr)
 
--- | CodePoint is an Int bounded between 0 and 0x10FFFF, corresponding to
+-- | CodePoint is an `Int` bounded between `0` and `0x10FFFF`, corresponding to
 -- | Unicode code points.
 newtype CodePoint = CodePoint Int
 
@@ -67,7 +67,7 @@ instance boundedEnumCodePoint :: BoundedEnum CodePoint where
     | n >= 0 && n <= 0x10FFFF = Just (CodePoint n)
     | otherwise = Nothing
 
--- | Creates a CodePoint from a given Char.
+-- | Creates a `CodePoint` from a given `Char`.
 -- |
 -- | ```purescript
 -- | >>> codePointFromChar 'B'
@@ -178,7 +178,7 @@ codePointAtFallback n s = case uncons s of
   _ -> Nothing
 
 -- | Returns a record with the first code point and the remaining code points
--- | of the string. Returns Nothing if the string is empty. Operates in
+-- | of the string. Returns `Nothing` if the string is empty. Operates in
 -- | constant space and time.
 -- |
 -- | ```purescript
@@ -243,7 +243,7 @@ countTail p s accum = case uncons s of
   _ -> accum
 
 -- | Returns the number of code points preceding the first match of the given
--- | pattern in the string. Returns Nothing when no matches are found.
+-- | pattern in the string. Returns `Nothing` when no matches are found.
 -- |
 -- | ```purescript
 -- | >>> indexOf (Pattern "𝐀") "b 𝐀𝐀 c 𝐀"
@@ -257,7 +257,7 @@ indexOf p s = (\i -> length (CU.take i s)) <$> CU.indexOf p s
 
 -- | Returns the number of code points preceding the first match of the given
 -- | pattern in the string. Pattern matches preceding the given index will be
--- | ignored. Returns Nothing when no matches are found.
+-- | ignored. Returns `Nothing` when no matches are found.
 -- |
 -- | ```purescript
 -- | >>> indexOf' (Pattern "𝐀") 4 "b 𝐀𝐀 c 𝐀"
@@ -272,7 +272,7 @@ indexOf' p i s =
   (\k -> i + length (CU.take k s')) <$> CU.indexOf p s'
 
 -- | Returns the number of code points preceding the last match of the given
--- | pattern in the string. Returns Nothing when no matches are found.
+-- | pattern in the string. Returns `Nothing` when no matches are found.
 -- |
 -- | ```purescript
 -- | >>> lastIndexOf (Pattern "𝐀") "b 𝐀𝐀 c 𝐀"
@@ -292,7 +292,7 @@ lastIndexOf p s = (\i -> length (CU.take i s)) <$> CU.lastIndexOf p s
 -- | greater than the number of code points in the string is equivalent to
 -- | searching in the whole string.
 -- |
--- | Returns Nothing when no matches are found.
+-- | Returns `Nothing` when no matches are found.
 -- |
 -- | ```purescript
 -- | >>> lastIndexOf' (Pattern "𝐀") (-1) "b 𝐀𝐀 c 𝐀"

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -37,7 +37,7 @@ import Data.String.Unsafe as U
 -------------------------------------------------------------------------------
 
 -- | If the string starts with the given prefix, return the portion of the
--- | string left after removing it, as a Just value. Otherwise, return Nothing.
+-- | string left after removing it, as a `Just` value. Otherwise, return `Nothing`.
 -- |
 -- | ```purescript
 -- | stripPrefix (Pattern "http:") "http://purescript.org" == Just "//purescript.org"


### PR DESCRIPTION
**Description of the change**

Surround code in docs with backticks.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
