### PR TITLE
Make `RegexFlags` a `newtype` and add a `Newtype` instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bugfixes:
 
 Other improvements:
 - Surround code with backticks in documentation (#148)
+- Make `RegexFlags` a `newtype` and a `Newtype` instance for it(#159 by @mhmdanas)
 
 ## [v5.0.0](https://github.com/purescript/purescript-strings/releases/tag/v5.0.0) - 2021-02-26
 

--- a/src/Data/String/Regex/Flags.purs
+++ b/src/Data/String/Regex/Flags.purs
@@ -3,6 +3,7 @@ module Data.String.Regex.Flags where
 import Prelude
 
 import Control.MonadPlus (guard)
+import Data.Newtype (class Newtype)
 import Data.String (joinWith)
 
 type RegexFlagsRec =
@@ -15,7 +16,9 @@ type RegexFlagsRec =
   }
 
 -- | Flags that control matching.
-data RegexFlags = RegexFlags RegexFlagsRec
+newtype RegexFlags = RegexFlags RegexFlagsRec
+
+derive instance newtypeRegexFlags :: Newtype RegexFlags _
 
 -- | All flags set to false.
 noFlags :: RegexFlags
@@ -107,14 +110,7 @@ instance semigroupRegexFlags :: Semigroup RegexFlags where
 instance monoidRegexFlags :: Monoid RegexFlags where
   mempty = noFlags
 
-instance eqRegexFlags :: Eq RegexFlags where
-  eq (RegexFlags x) (RegexFlags y)
-    = x.global == y.global
-    && x.ignoreCase == y.ignoreCase
-    && x.multiline == y.multiline
-    && x.dotAll == y.dotAll
-    && x.sticky == y.sticky
-    && x.unicode == y.unicode
+derive newtype instance eqRegexFlags :: Eq RegexFlags
 
 instance showRegexFlags :: Show RegexFlags where
   show (RegexFlags flags) =


### PR DESCRIPTION
**Description of the change**

Make `RegexFlags` a `newtype` and add a `Newtype` instance for it. I just thought that since it's merely wrapping a record, making it a `newtype` sounds appropriate.

I also refactored the `Eq` instance.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
