### PR TITLE
Derive `newtype` instances where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Derive `newtype` instances where possible (#166 by @mhmdanas)
 
 ## [v6.0.1](https://github.com/purescript/purescript-strings/releases/tag/v6.0.1) - 2022-08-16
 

--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -46,8 +46,8 @@ import Data.Unfoldable (unfoldr)
 -- | Unicode code points.
 newtype CodePoint = CodePoint Int
 
-derive instance eqCodePoint :: Eq CodePoint
-derive instance ordCodePoint :: Ord CodePoint
+derive newtype instance eqCodePoint :: Eq CodePoint
+derive newtype instance ordCodePoint :: Ord CodePoint
 
 instance showCodePoint :: Show CodePoint where
   show (CodePoint i) = "(CodePoint 0x" <> toUpper (toStringAs hexadecimal i) <> ")"

--- a/src/Data/String/Pattern.purs
+++ b/src/Data/String/Pattern.purs
@@ -15,8 +15,8 @@ import Data.Newtype (class Newtype)
 -- |
 newtype Pattern = Pattern String
 
-derive instance eqPattern :: Eq Pattern
-derive instance ordPattern :: Ord Pattern
+derive newtype instance eqPattern :: Eq Pattern
+derive newtype instance ordPattern :: Ord Pattern
 derive instance newtypePattern :: Newtype Pattern _
 
 instance showPattern :: Show Pattern where
@@ -25,8 +25,8 @@ instance showPattern :: Show Pattern where
 -- | A newtype used in cases to specify a replacement for a pattern.
 newtype Replacement = Replacement String
 
-derive instance eqReplacement :: Eq Replacement
-derive instance ordReplacement :: Ord Replacement
+derive newtype instance eqReplacement :: Eq Replacement
+derive newtype instance ordReplacement :: Ord Replacement
 derive instance newtypeReplacement :: Newtype Replacement _
 
 instance showReplacement :: Show Replacement where


### PR DESCRIPTION
**Description of the change**

Derive `newtype` instances instead of "normal" instances where possible, which produces smaller code.
---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
