### PR TITLE
Better definition for `Data.String.NonEmpty.CodeUnits.fromFoldable1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Bugfixes:
 
 Other improvements:
 
+## [v6.0.2]
+
+Other improvements:
+- Redefine `Data.String.NonEmpty.CodeUnits.fromFoldable1` in terms of `singleton` (#168 by @postsolar)
+
 ## [v6.0.1](https://github.com/purescript/purescript-strings/releases/tag/v6.0.1) - 2022-08-16
 
 Bugfixes:

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -297,9 +297,9 @@ dropWhile :: (Char -> Boolean) -> String -> String
 dropWhile p s = drop (countPrefix p s) s
 
 -- | Returns the substring at indices `[begin, end)`.
--- | If either index is negative, it is normalised to `length s + index`,
--- | where `s` is the input string. `""` is returned if
--- | `begin > end` after normalisation.
+-- | If either index is negative, it is normalised to `length s - index`,
+-- | where `s` is the input string. `""` is returned if either
+-- | index is out of bounds or if `begin > end` after normalisation.
 -- |
 -- | ```purescript
 -- | slice 0 0   "purescript" == ""

--- a/src/Data/String/CodeUnits.purs
+++ b/src/Data/String/CodeUnits.purs
@@ -297,9 +297,9 @@ dropWhile :: (Char -> Boolean) -> String -> String
 dropWhile p s = drop (countPrefix p s) s
 
 -- | Returns the substring at indices `[begin, end)`.
--- | If either index is negative, it is normalised to `length s - index`,
--- | where `s` is the input string. `""` is returned if either
--- | index is out of bounds or if `begin > end` after normalisation.
+-- | If either index is negative, it is normalised to `length s + index`,
+-- | where `s` is the input string. `""` is returned if
+-- | `begin > end` after normalisation.
 -- |
 -- | ```purescript
 -- | slice 0 0   "purescript" == ""

--- a/src/Data/String/NonEmpty/CodeUnits.purs
+++ b/src/Data/String/NonEmpty/CodeUnits.purs
@@ -37,7 +37,6 @@ import Data.String.NonEmpty.Internal (NonEmptyString(..), fromString)
 import Data.String.Pattern (Pattern)
 import Data.String.Unsafe as U
 import Partial.Unsafe (unsafePartial)
-import Unsafe.Coerce (unsafeCoerce)
 
 -- For internal use only. Do not export.
 toNonEmptyString :: String -> NonEmptyString
@@ -91,7 +90,7 @@ snoc c s = toNonEmptyString (s <> CU.singleton c)
 -- | Creates a `NonEmptyString` from a `Foldable1` container carrying
 -- | characters.
 fromFoldable1 :: forall f. Foldable1 f => f Char -> NonEmptyString
-fromFoldable1 = unsafeCoerce <<< F1.foldMap1 CU.singleton
+fromFoldable1 = F1.foldMap1 singleton
 
 -- | Converts the `NonEmptyString` into an array of characters.
 -- |

--- a/src/Data/String/NonEmpty/CodeUnits.purs
+++ b/src/Data/String/NonEmpty/CodeUnits.purs
@@ -91,10 +91,7 @@ snoc c s = toNonEmptyString (s <> CU.singleton c)
 -- | Creates a `NonEmptyString` from a `Foldable1` container carrying
 -- | characters.
 fromFoldable1 :: forall f. Foldable1 f => f Char -> NonEmptyString
-fromFoldable1 = F1.fold1 <<< coe
-  where
-    coe ∷ f Char -> f NonEmptyString
-    coe = unsafeCoerce
+fromFoldable1 = unsafeCoerce <<< F1.foldMap1 CU.singleton
 
 -- | Converts the `NonEmptyString` into an array of characters.
 -- |


### PR DESCRIPTION
Current definition of `Data.String.CodeUnits.NonEmpty.fromFoldable1` uses `unsafeCoerce` to coerce an array of characters into array of non-empty strings. This is 1) unsuitable for some backends; 2) could be redefined via `singleton :: Char -> String`.

I also slipped in a small doc comment update.

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
