### PR TITLE
Update take docstring to match the behaviour

### DIFF
--- a/src/Data/String/CodePoints.purs
+++ b/src/Data/String/CodePoints.purs
@@ -314,7 +314,7 @@ lastIndexOf' p i s =
 
 -- | Returns a string containing the given number of code points from the
 -- | beginning of the given string. If the string does not have that many code
--- | points, returns the empty string. Operates in constant space and in time
+-- | points, returns the entire string. Operates in constant space and in time
 -- | linear to the given number.
 -- |
 -- | ```purescript


### PR DESCRIPTION
This is a documentation-only change to reconcile the documentation of `Data.String.CodePoints.take` with the behaviour. The behaviour of `take` is to return the first N characters of the string, or the *entire* input string if the length is less than N. The falllback and direct implementations appear to agree on this. The tests verify this behaviour (`str` length is 7):

```
  assertEqual
    { actual: SCP.take 8 str
    , expected: str
    }
```